### PR TITLE
Bugfix: Cross product was not returning a 4d vector

### DIFF
--- a/src/giskardpy/application.py
+++ b/src/giskardpy/application.py
@@ -3,6 +3,7 @@ import traceback
 import rospy
 
 class ROSApplication(object):
+    """Superclass for all giskard ROS applications. Runs a process manager until it terminates."""
     # TODO do we still have this class?
     def __init__(self, process_manager):
         self.process_manager = process_manager

--- a/src/giskardpy/process_manager.py
+++ b/src/giskardpy/process_manager.py
@@ -10,17 +10,31 @@ from giskardpy.exceptions import NameConflictException, MAX_NWSR_REACHEDExceptio
 
 
 class ProcessManager(object):
+    """A process manager whom plugins can be registered to, which are then executed regularly."""
+
     def __init__(self, initial_state=None):
+        """Initializes the process manager.
+
+        Arguments:
+        initial_state -- An initial god map for this process manager
+        """
         self._plugins = OrderedDict()
         self._god_map = GodMap() if initial_state is None else copy(initial_state)
         self.original_universe = initial_state is None
 
+
     def register_plugin(self, name, plugin):
+        """Registers a plugin with the process manager. The name needs to be unique."""
         if name in self._plugins:
             raise NameConflictException('A plugin with name "{}" already exists.'.format(name))
         self._plugins[name] = plugin
 
     def start_loop(self):
+        """Starts the loop of the project manager.
+
+        Calls start() on all registered plugins. Will continuously update itself, 
+        until it is stopped or the ROS node is shut down.
+        """
         for plugin in self._plugins.values():
             plugin.start(self._god_map)
             # TODO is it really a good idea to call get_readings here?
@@ -33,13 +47,25 @@ class ProcessManager(object):
                 rospy.sleep(0.1)
 
     def stop(self):
+        """Calls stop() on all registered plugins."""
         for plugin in self._plugins.values():
             plugin.stop()
 
     def get_god_map(self):
+        """Returns the process manager's god map."""
         return self._god_map
 
     def update(self):
+        """Calls update on registered plugins.
+
+        Sequentially calls the update function on registered plugins.
+        If a plugin calls for the creation of a new parallel universe,
+        it is created, a new process manager is created, replacements for
+        the registered plugins are registered to it and the new process manager
+        is updated until it terminates. Its resulting god map is copied to the old god map.
+
+        Returns True as long as no plugin calls for the destruction of a parallel universe.
+        """
         # TODO doesn't die during planning
         for plugin_name, plugin in self._plugins.items():
             while True:

--- a/src/giskardpy/symengine_robot.py
+++ b/src/giskardpy/symengine_robot.py
@@ -88,7 +88,9 @@ class Robot(object):
 
             if joint.type in ['fixed', 'revolute', 'continuous', 'prismatic']:
                 if joint.origin is not None:
-                    joint_frame = spw.translation3(*joint.origin.xyz) * spw.rotation3_rpy(*joint.origin.rpy)
+                    xyz = joint.origin.xyz if joint.origin.xyz is not None else [0,0,0]
+                    rpy = joint.origin.rpy if joint.origin.rpy is not None else [0,0,0]
+                    joint_frame = spw.translation3(*xyz) * spw.rotation3_rpy(*rpy)
                 else:
                     joint_frame = spw.eye(4)
             else:

--- a/src/giskardpy/symengine_wrappers.py
+++ b/src/giskardpy/symengine_wrappers.py
@@ -161,7 +161,7 @@ def speed_up(function, parameters, backend='llvm'):
 def cross(u, v):
     return sp.Matrix([u[1] * v[2] - u[2] * v[1],
                       u[2] * v[0] - u[0] * v[2],
-                      u[0] * v[1] - u[1] * v[0]])
+                      u[0] * v[1] - u[1] * v[0], 0])
 
 
 def vector3(x, y, z):

--- a/src/giskardpy/symengine_wrappers.py
+++ b/src/giskardpy/symengine_wrappers.py
@@ -192,7 +192,7 @@ def dot(a, b):
     return (a.T*b)[0]
 
 
-def translation3(x, y, z):
+def translation3(x, y, z, w=1):
     r = sp.eye(4)
     r[0, 3] = x
     r[1, 3] = y


### PR DESCRIPTION
The cross product calculation in "symengine_wrappers.py" was not returning a 4d vector, but a simple 3d one. Since Giskard uses a 4d homogeneous coordinate system, this function should follow that scheme.