### PR TITLE
Devel

### DIFF
--- a/src/giskardpy/python_interface.py
+++ b/src/giskardpy/python_interface.py
@@ -50,7 +50,7 @@ class GiskardWrapper(object):
         """
         return self.robot_urdf.get_root()
 
-    def set_cart_goal(self, root_link, tip_link, goal_pose, max_linear_velocity=None, max_angular_velocity=None, weight=None):
+    def set_cart_goal(self, goal_pose, tip_link, root_link, max_linear_velocity=None, max_angular_velocity=None, weight=None):
         """
         This goal will use the kinematic chain between root and tip link to move tip link into the goal pose
         :param root_link: name of the root link of the kin chain
@@ -66,10 +66,10 @@ class GiskardWrapper(object):
         :param weight: default WEIGHT_ABOVE_CA
         :type weight: float
         """
-        self.set_translation_goal(root_link, tip_link, goal_pose, max_velocity=max_linear_velocity, weight=weight)
-        self.set_rotation_goal(root_link, tip_link, goal_pose, max_velocity=max_angular_velocity, weight=weight)
+        self.set_translation_goal(goal_pose, tip_link, root_link, weight=weight, max_velocity=max_linear_velocity)
+        self.set_rotation_goal(goal_pose, tip_link, root_link, weight=weight, max_velocity=max_angular_velocity)
 
-    def set_translation_goal(self, root_link, tip_link, goal_pose, weight=None, max_velocity=None):
+    def set_translation_goal(self, goal_pose, tip_link, root_link, weight=None, max_velocity=None):
         """
         This goal will use the kinematic chain between root and tip link to move tip link into the goal position
         :param root_link: name of the root link of the kin chain
@@ -104,7 +104,7 @@ class GiskardWrapper(object):
             constraint.parameter_value_pair = json.dumps(params)
             self.cmd_seq[-1].constraints.append(constraint)
 
-    def set_rotation_goal(self, root_link, tip_link, goal_pose, weight=None, max_velocity=None):
+    def set_rotation_goal(self, goal_pose, tip_link, root_link, weight=None, max_velocity=None):
         """
         This goal will use the kinematic chain between root and tip link to move tip link into the goal orientation
         :param root_link: name of the root link of the kin chain

--- a/src/giskardpy/utils.py
+++ b/src/giskardpy/utils.py
@@ -927,7 +927,8 @@ def publish_marker_vector(start, end, diameter_shaft=0.01, diameter_head=0.02,  
     m.scale.z = 0
 
     pub = rospy.Publisher('/visualization_marker', Marker, queue_size=1)
-    while pub.get_num_connections() < 1:
+    start = rospy.get_rostime()
+    while pub.get_num_connections() < 1 and (rospy.get_rostime() - start).to_sec() < 2:
         # wait for a connection to publisher
         # you can do whatever you like here or simply do nothing
         pass

--- a/src/giskardpy/utils.py
+++ b/src/giskardpy/utils.py
@@ -897,7 +897,8 @@ def publish_marker_sphere(position, frame_id=u'map', radius=0.05, id_=0):
     m.scale.z = radius
 
     pub = rospy.Publisher('/visualization_marker', Marker, queue_size=1)
-    while pub.get_num_connections() < 1:
+    start = rospy.get_rostime()
+    while pub.get_num_connections() < 1 and (rospy.get_rostime() - start).to_sec() < 2:
         # wait for a connection to publisher
         # you can do whatever you like here or simply do nothing
         pass

--- a/test/test_integration_boxy.py
+++ b/test/test_integration_boxy.py
@@ -195,7 +195,7 @@ class TestConstraints(object):
     def test_pointing(self, better_pose):
         tip = u'head_mount_kinect2_rgb_optical_frame'
         goal_point = lookup_point(u'map', better_pose.r_tip)
-        better_pose.wrapper.pointing(tip, goal_point)
+        better_pose.pointing(tip, goal_point)
         better_pose.send_and_check_goal()
 
         current_x = Vector3Stamped()
@@ -207,7 +207,7 @@ class TestConstraints(object):
         np.testing.assert_almost_equal(expected_x.point.x, 0, 2)
 
         goal_point = lookup_point(u'map', better_pose.r_tip)
-        better_pose.wrapper.pointing(tip, goal_point, root=better_pose.r_tip)
+        better_pose.pointing(tip, goal_point, root=better_pose.r_tip)
 
         r_goal = PoseStamped()
         r_goal.header.frame_id = better_pose.r_tip
@@ -247,7 +247,7 @@ class TestConstraints(object):
         tip_grasp_axis.header.frame_id = kitchen_setup.l_tip
         tip_grasp_axis.vector.y = 1
 
-        kitchen_setup.add_json_goal(u'GraspBar',
+        kitchen_setup.set_json_goal(u'GraspBar',
                                     root=kitchen_setup.default_root,
                                     tip=kitchen_setup.l_tip,
                                     tip_grasp_axis=tip_grasp_axis,
@@ -272,7 +272,7 @@ class TestConstraints(object):
         kitchen_setup.allow_all_collisions()  # makes execution faster
         kitchen_setup.send_and_check_goal()  # send goal to Giskard
 
-        kitchen_setup.add_json_goal(u'Open',
+        kitchen_setup.set_json_goal(u'Open',
                                     tip=kitchen_setup.l_tip,
                                     object_name=u'kitchen',
                                     handle_link=handle_name)
@@ -282,7 +282,7 @@ class TestConstraints(object):
         kitchen_setup.set_kitchen_js({u'sink_area_left_middle_drawer_main_joint': 0.48})
 
         # Close drawer partially
-        kitchen_setup.add_json_goal(u'OpenDrawer',
+        kitchen_setup.set_json_goal(u'OpenDrawer',
                                     tip=kitchen_setup.l_tip,
                                     object_name=u'kitchen',
                                     handle_link=handle_name,
@@ -292,7 +292,7 @@ class TestConstraints(object):
         # Update kitchen object
         kitchen_setup.set_kitchen_js({u'sink_area_left_middle_drawer_main_joint': 0.2})
 
-        kitchen_setup.add_json_goal(u'Close',
+        kitchen_setup.set_json_goal(u'Close',
                                     tip=kitchen_setup.l_tip,
                                     object_name=u'kitchen',
                                     handle_link=handle_name)

--- a/test/test_integration_donbot.py
+++ b/test/test_integration_donbot.py
@@ -395,7 +395,7 @@ class TestConstraints(object):
         zero_pose.set_and_check_cart_goal(box_pose, u'refills_tool_frame', u'base_footprint')
 
         zero_pose.add_box(box, [0.035, 0.12, 0.15], box_pose)
-        zero_pose.attach_existing(box, u'refills_finger')
+        zero_pose.attach_object(box, u'refills_finger')
 
         # go_up_pose = PoseStamped()
         # go_up_pose.header.frame_id = u'refills_finger'
@@ -411,7 +411,7 @@ class TestConstraints(object):
     def test_pointing(self, better_pose):
         tip = u'rs_camera_link'
         goal_point = tf.lookup_point(u'map', u'base_footprint')
-        better_pose.wrapper.pointing(tip, goal_point)
+        better_pose.pointing(tip, goal_point)
         better_pose.send_and_check_goal()
 
         current_x = Vector3Stamped()
@@ -423,7 +423,7 @@ class TestConstraints(object):
         np.testing.assert_almost_equal(expected_x.point.x, 0, 2)
 
         # goal_point = tf.lookup_point(u'map', tip)
-        # better_pose.wrapper.pointing(tip, goal_point, root=tip)
+        # better_pose.pointing(tip, goal_point, root=tip)
         #
         # r_goal = PoseStamped()
         # r_goal.header.frame_id = tip
@@ -543,7 +543,7 @@ class TestCollisionAvoidanceGoals(object):
         p.pose.orientation = Quaternion(0, 0, 0, 1)
 
         better_pose.add_box(pocky, [0.05, 0.2, 0.03], p)
-        better_pose.attach_existing(pocky, frame_id=u'refills_finger')
+        better_pose.attach_object(pocky, frame_id=u'refills_finger')
 
         tip_normal = Vector3Stamped()
         tip_normal.header.frame_id = pocky
@@ -561,7 +561,7 @@ class TestCollisionAvoidanceGoals(object):
         pocky_goal.pose.position.z = -.2
         pocky_goal.pose.orientation.w = 1
         better_pose.allow_self_collision()
-        better_pose.set_translation_goal(pocky_goal, pocky, u'base_footprint')
+        better_pose.set_translation_goal(u'base_footprint', pocky, pocky_goal)
         better_pose.send_and_check_goal()
 
     def test_avoid_collision2(self, better_pose):
@@ -682,14 +682,14 @@ class TestCollisionAvoidanceGoals(object):
         # shelf_setup.allow_all_collisions()
         shelf_setup.set_and_check_cart_goal(grasp_pose, u'refills_finger')
 
-        shelf_setup.attach_existing(box, u'refills_finger')
+        shelf_setup.attach_object(box, u'refills_finger')
 
         box_goal = PoseStamped()
         box_goal.header.frame_id = u'map'
         box_goal.pose.position.z = 1.12
         box_goal.pose.position.y = -.9
         grasp_pose.pose.orientation.w = 1
-        shelf_setup.set_translation_goal(box_goal, box)
+        shelf_setup.set_translation_goal(, box, box_goal
 
         tip_normal = Vector3Stamped()
         tip_normal.header.frame_id = box
@@ -706,7 +706,7 @@ class TestCollisionAvoidanceGoals(object):
         box_goal.pose.position.y = -0.2
         box_goal.pose.orientation.w = 1
         # shelf_setup.set_cart_goal(box_goal, box)
-        shelf_setup.set_translation_goal(box_goal, box)
+        shelf_setup.set_translation_goal(, box, box_goal
 
         tip_normal = Vector3Stamped()
         tip_normal.header.frame_id = box
@@ -750,7 +750,7 @@ class TestCollisionAvoidanceGoals(object):
         goal_js = {
             u'ur5_shoulder_lift_joint': .5,
         }
-        # zero_pose.wrapper.set_self_collision_distance(0.025)
+        # zero_pose.set_self_collision_distance(0.025)
         zero_pose.allow_self_collision()
         zero_pose.send_and_check_joint_goal(goal_js)
 
@@ -758,7 +758,7 @@ class TestCollisionAvoidanceGoals(object):
         arm_goal.header.frame_id = zero_pose.gripper_tip
         arm_goal.pose.position.y = -.1
         arm_goal.pose.orientation.w = 1
-        # zero_pose.wrapper.set_self_collision_distance(0.025)
+        # zero_pose.set_self_collision_distance(0.025)
         zero_pose.set_and_check_cart_goal(arm_goal, zero_pose.gripper_tip, zero_pose.default_root)
 
     def test_avoid_self_collision2(self, self_collision_pose):
@@ -775,6 +775,6 @@ class TestCollisionAvoidanceGoals(object):
         ce = CollisionEntry()
         ce.type = CollisionEntry.AVOID_COLLISION
         ce.body_b = u'asdf'
-        zero_pose.add_collision_entries([ce])
+        zero_pose.set_collision_entries([ce])
         zero_pose.send_and_check_goal(MoveResult.UNKNOWN_OBJECT)
         zero_pose.send_and_check_goal()

--- a/test/test_integration_donbot.py
+++ b/test/test_integration_donbot.py
@@ -395,7 +395,7 @@ class TestConstraints(object):
         zero_pose.set_and_check_cart_goal(box_pose, u'refills_tool_frame', u'base_footprint')
 
         zero_pose.add_box(box, [0.035, 0.12, 0.15], box_pose)
-        zero_pose.attach_object(box, u'refills_finger')
+        zero_pose.attach_existing(box, u'refills_finger')
 
         # go_up_pose = PoseStamped()
         # go_up_pose.header.frame_id = u'refills_finger'
@@ -411,7 +411,7 @@ class TestConstraints(object):
     def test_pointing(self, better_pose):
         tip = u'rs_camera_link'
         goal_point = tf.lookup_point(u'map', u'base_footprint')
-        better_pose.pointing(tip, goal_point)
+        better_pose.wrapper.pointing(tip, goal_point)
         better_pose.send_and_check_goal()
 
         current_x = Vector3Stamped()
@@ -423,7 +423,7 @@ class TestConstraints(object):
         np.testing.assert_almost_equal(expected_x.point.x, 0, 2)
 
         # goal_point = tf.lookup_point(u'map', tip)
-        # better_pose.pointing(tip, goal_point, root=tip)
+        # better_pose.wrapper.pointing(tip, goal_point, root=tip)
         #
         # r_goal = PoseStamped()
         # r_goal.header.frame_id = tip
@@ -543,7 +543,7 @@ class TestCollisionAvoidanceGoals(object):
         p.pose.orientation = Quaternion(0, 0, 0, 1)
 
         better_pose.add_box(pocky, [0.05, 0.2, 0.03], p)
-        better_pose.attach_object(pocky, frame_id=u'refills_finger')
+        better_pose.attach_existing(pocky, frame_id=u'refills_finger')
 
         tip_normal = Vector3Stamped()
         tip_normal.header.frame_id = pocky
@@ -561,7 +561,7 @@ class TestCollisionAvoidanceGoals(object):
         pocky_goal.pose.position.z = -.2
         pocky_goal.pose.orientation.w = 1
         better_pose.allow_self_collision()
-        better_pose.set_translation_goal(u'base_footprint', pocky, pocky_goal)
+        better_pose.set_translation_goal(pocky_goal, pocky, u'base_footprint')
         better_pose.send_and_check_goal()
 
     def test_avoid_collision2(self, better_pose):
@@ -682,14 +682,14 @@ class TestCollisionAvoidanceGoals(object):
         # shelf_setup.allow_all_collisions()
         shelf_setup.set_and_check_cart_goal(grasp_pose, u'refills_finger')
 
-        shelf_setup.attach_object(box, u'refills_finger')
+        shelf_setup.attach_existing(box, u'refills_finger')
 
         box_goal = PoseStamped()
         box_goal.header.frame_id = u'map'
         box_goal.pose.position.z = 1.12
         box_goal.pose.position.y = -.9
         grasp_pose.pose.orientation.w = 1
-        shelf_setup.set_translation_goal(, box, box_goal
+        shelf_setup.set_translation_goal(box_goal, box)
 
         tip_normal = Vector3Stamped()
         tip_normal.header.frame_id = box
@@ -706,7 +706,7 @@ class TestCollisionAvoidanceGoals(object):
         box_goal.pose.position.y = -0.2
         box_goal.pose.orientation.w = 1
         # shelf_setup.set_cart_goal(box_goal, box)
-        shelf_setup.set_translation_goal(, box, box_goal
+        shelf_setup.set_translation_goal(box_goal, box)
 
         tip_normal = Vector3Stamped()
         tip_normal.header.frame_id = box
@@ -750,7 +750,7 @@ class TestCollisionAvoidanceGoals(object):
         goal_js = {
             u'ur5_shoulder_lift_joint': .5,
         }
-        # zero_pose.set_self_collision_distance(0.025)
+        # zero_pose.wrapper.set_self_collision_distance(0.025)
         zero_pose.allow_self_collision()
         zero_pose.send_and_check_joint_goal(goal_js)
 
@@ -758,7 +758,7 @@ class TestCollisionAvoidanceGoals(object):
         arm_goal.header.frame_id = zero_pose.gripper_tip
         arm_goal.pose.position.y = -.1
         arm_goal.pose.orientation.w = 1
-        # zero_pose.set_self_collision_distance(0.025)
+        # zero_pose.wrapper.set_self_collision_distance(0.025)
         zero_pose.set_and_check_cart_goal(arm_goal, zero_pose.gripper_tip, zero_pose.default_root)
 
     def test_avoid_self_collision2(self, self_collision_pose):
@@ -775,6 +775,6 @@ class TestCollisionAvoidanceGoals(object):
         ce = CollisionEntry()
         ce.type = CollisionEntry.AVOID_COLLISION
         ce.body_b = u'asdf'
-        zero_pose.set_collision_entries([ce])
+        zero_pose.add_collision_entries([ce])
         zero_pose.send_and_check_goal(MoveResult.UNKNOWN_OBJECT)
         zero_pose.send_and_check_goal()

--- a/test/test_integration_hsr.py
+++ b/test/test_integration_hsr.py
@@ -174,7 +174,7 @@ class TestCollisionAvoidanceGoals(object):
                                                                           [1, 0, 0, 0],
                                                                           [0, 0, 0, 1]]))
         box_setup.set_and_check_cart_goal(grasp_pose, box_setup.tip)
-        box_setup.attach_existing(box_name, box_setup.tip)
+        box_setup.attach_object(box_name, box_setup.tip)
 
         base_goal = PoseStamped()
         base_goal.header.frame_id = box_setup.default_root

--- a/test/test_integration_pr2.py
+++ b/test/test_integration_pr2.py
@@ -333,7 +333,7 @@ class TestJointGoals(object):
         zero_pose.allow_self_collision()
         zero_pose.set_joint_goal(pocky_pose)
         zero_pose.send_and_check_goal(goal_type=MoveGoal.PLAN_ONLY)
-        zero_pose.check_joint_state(default_pose)
+        zero_pose.check_current_joint_state(default_pose)
 
     def test_prismatic_joint1(self, zero_pose):
         """
@@ -401,7 +401,7 @@ class TestConstraints(object):
     def test_CartesianVelocityLimit(self, zero_pose):
         linear_velocity = 1
         angular_velocity = 1
-        zero_pose.wrapper.limit_cartesian_velocity(
+        zero_pose.limit_cartesian_velocity(
                                 root_link=zero_pose.default_root,
                                 tip_link=u'base_footprint',
                                 max_linear_velocity=0.1,
@@ -426,7 +426,7 @@ class TestConstraints(object):
         """
         percentage = 10
         zero_pose.allow_self_collision()
-        zero_pose.wrapper.avoid_joint_limits(percentage=percentage)
+        zero_pose.avoid_joint_limits(percentage=percentage)
         zero_pose.send_and_check_goal()
 
         joint_non_continuous = [j for j in zero_pose.get_robot().controlled_joints if
@@ -454,13 +454,13 @@ class TestConstraints(object):
         del goal_state[u'odom_x_joint']
         del goal_state[u'odom_y_joint']
         zero_pose.allow_self_collision()
-        zero_pose.add_json_goal(u'AvoidJointLimits',
+        zero_pose.set_json_goal(u'AvoidJointLimits',
                                 percentage=percentage)
         zero_pose.set_joint_goal(goal_state)
         zero_pose.send_and_check_goal()
 
         zero_pose.allow_self_collision()
-        zero_pose.add_json_goal(u'AvoidJointLimits',
+        zero_pose.set_json_goal(u'AvoidJointLimits',
                                 percentage=percentage)
         zero_pose.send_and_check_goal()
 
@@ -503,7 +503,7 @@ class TestConstraints(object):
 
         old_pose = tf.lookup_pose(u'map', u'base_footprint')
 
-        pocky_pose_setup.wrapper.update_god_map(updates)
+        pocky_pose_setup.update_god_map(updates)
         pocky_pose_setup.set_and_check_cart_goal(r_goal, pocky_pose_setup.r_tip)
 
         new_pose = tf.lookup_pose(u'map', u'base_footprint')
@@ -526,7 +526,7 @@ class TestConstraints(object):
         }
         # old_pose = tf.lookup_pose(u'map', u'base_footprint')
         # old_pose.pose.position.x += 0.1
-        pocky_pose_setup.wrapper.update_god_map(updates)
+        pocky_pose_setup.update_god_map(updates)
         pocky_pose_setup.set_and_check_cart_goal(r_goal, pocky_pose_setup.r_tip)
 
         new_pose = tf.lookup_pose(u'map', u'base_footprint')
@@ -547,12 +547,12 @@ class TestConstraints(object):
         :param pocky_pose_setup: PR2
         """
         # FIXME idk
-        pocky_pose_setup.add_json_goal(u'BasePointingForward')
+        pocky_pose_setup.set_json_goal(u'BasePointingForward')
         r_goal = PoseStamped()
         r_goal.header.frame_id = pocky_pose_setup.r_tip
         r_goal.pose.position.y = -2
         r_goal.pose.orientation.w = 1
-        pocky_pose_setup.add_json_goal(u'CartesianVelocityLimit',
+        pocky_pose_setup.set_json_goal(u'CartesianVelocityLimit',
                                        root_link=pocky_pose_setup.default_root,
                                        tip_link=u'base_footprint',
                                        max_linear_velocity=0.1,
@@ -583,7 +583,7 @@ class TestConstraints(object):
                 }
             }
         }
-        pocky_pose_setup.wrapper.update_god_map(updates)
+        pocky_pose_setup.update_god_map(updates)
         pocky_pose_setup.set_cart_goal(r_goal, pocky_pose_setup.r_tip)
         pocky_pose_setup.send_and_check_goal(expected_error_codes=[MoveResult.ERROR])
         assert pocky_pose_setup.get_god_map().unsafe_get_data(
@@ -610,7 +610,7 @@ class TestConstraints(object):
                 }
             }
         }
-        pocky_pose_setup.wrapper.update_god_map(updates)
+        pocky_pose_setup.update_god_map(updates)
         pocky_pose_setup.set_cart_goal(r_goal, pocky_pose_setup.r_tip)
         pocky_pose_setup.send_and_check_goal(expected_error_codes=[MoveResult.ERROR])
         assert pocky_pose_setup.get_god_map().unsafe_get_data(
@@ -630,15 +630,15 @@ class TestConstraints(object):
         pointing_axis = Vector3Stamped()
         pointing_axis.header.frame_id = tip
         pointing_axis.vector.x = 1
-        kitchen_setup.wrapper.pointing(tip, goal_point, pointing_axis=pointing_axis)
+        kitchen_setup.pointing(tip, goal_point, pointing_axis=pointing_axis)
         kitchen_setup.send_and_check_goal()
 
         base_goal = PoseStamped()
         base_goal.header.frame_id = u'base_footprint'
         base_goal.pose.position.y = 2
         base_goal.pose.orientation = Quaternion(*quaternion_about_axis(1, [0, 0, 1]))
-        kitchen_setup.wrapper.pointing(tip, goal_point, pointing_axis=pointing_axis)
-        kitchen_setup.add_json_goal(u'CartesianVelocityLimit',
+        kitchen_setup.pointing(tip, goal_point, pointing_axis=pointing_axis)
+        kitchen_setup.set_json_goal(u'CartesianVelocityLimit',
                                     root_link=kitchen_setup.default_root,
                                     tip_link=u'base_footprint',
                                     max_linear_velocity=0.1,
@@ -660,7 +660,7 @@ class TestConstraints(object):
         pointing_axis = Vector3Stamped()
         pointing_axis.header.frame_id = tip
         pointing_axis.vector.x = 1
-        kitchen_setup.wrapper.pointing(tip, goal_point, pointing_axis=pointing_axis, root_link=kitchen_setup.r_tip)
+        kitchen_setup.pointing(tip, goal_point, pointing_axis=pointing_axis, root_link=kitchen_setup.r_tip)
 
         r_goal = PoseStamped()
         r_goal.header.frame_id = kitchen_setup.r_tip
@@ -715,7 +715,7 @@ class TestConstraints(object):
         goal_state.name = [u'r_elbow_flex_joint']
         goal_state.position = [-1.0]
         kwargs = {u'goal_state': goal_state}
-        zero_pose.add_json_goal(u'jointpos', **kwargs)
+        zero_pose.set_json_goal(u'jointpos', **kwargs)
         zero_pose.send_and_check_goal(expected_error_codes=[MoveResult.UNKNOWN_CONSTRAINT])
 
     def test_python_code_in_constraint_type(self, zero_pose):
@@ -723,7 +723,7 @@ class TestConstraints(object):
         goal_state.name = [u'r_elbow_flex_joint']
         goal_state.position = [-1.0]
         kwargs = {u'goal_state': goal_state}
-        zero_pose.add_json_goal(u'print("asd")', **kwargs)
+        zero_pose.set_json_goal(u'print("asd")', **kwargs)
         zero_pose.send_and_check_goal(expected_error_codes=[MoveResult.UNKNOWN_CONSTRAINT])
 
     def test_wrong_params1(self, zero_pose):
@@ -731,7 +731,7 @@ class TestConstraints(object):
         goal_state.name = u'r_elbow_flex_joint'
         goal_state.position = [-1.0]
         kwargs = {u'goal_state': goal_state}
-        zero_pose.add_json_goal(u'JointPositionList', **kwargs)
+        zero_pose.set_json_goal(u'JointPositionList', **kwargs)
         zero_pose.send_and_check_goal(expected_error_codes=[MoveResult.CONSTRAINT_INITIALIZATION_ERROR])
 
     def test_wrong_params2(self, zero_pose):
@@ -739,7 +739,7 @@ class TestConstraints(object):
         goal_state.name = [5432]
         goal_state.position = u'test'
         kwargs = {u'goal_state': goal_state}
-        zero_pose.add_json_goal(u'JointPositionList', **kwargs)
+        zero_pose.set_json_goal(u'JointPositionList', **kwargs)
         zero_pose.send_and_check_goal(expected_error_codes=[MoveResult.CONSTRAINT_INITIALIZATION_ERROR])
 
     def test_align_planes2(self, zero_pose):
@@ -779,7 +779,7 @@ class TestConstraints(object):
         tip_grasp_axis.header.frame_id = kitchen_setup.r_tip
         tip_grasp_axis.vector.z = 1
 
-        kitchen_setup.add_json_goal(u'GraspBar',
+        kitchen_setup.set_json_goal(u'GraspBar',
                                     root_link=kitchen_setup.default_root,
                                     tip_link=kitchen_setup.r_tip,
                                     tip_grasp_axis=tip_grasp_axis,
@@ -816,7 +816,7 @@ class TestConstraints(object):
         tip_grasp_axis.header.frame_id = kitchen_setup.r_tip
         tip_grasp_axis.vector.z = 1
 
-        kitchen_setup.add_json_goal(u'GraspBar',
+        kitchen_setup.set_json_goal(u'GraspBar',
                                     root_link=kitchen_setup.default_root,
                                     tip_link=kitchen_setup.r_tip,
                                     tip_grasp_axis=tip_grasp_axis,
@@ -832,28 +832,28 @@ class TestConstraints(object):
         x_goal.vector.x = -1
         kitchen_setup.align_planes(kitchen_setup.r_tip, x_gripper, root_normal=x_goal, weight=WEIGHT_BELOW_CA)
         # kitchen_setup.allow_all_collisions()
-        kitchen_setup.add_json_goal(u'AvoidJointLimits', percentage=percentage)
-        kitchen_setup.wrapper.limit_cartesian_velocity(u'odom_combined', u'base_footprint', max_linear_velocity=0.1,
+        kitchen_setup.set_json_goal(u'AvoidJointLimits', percentage=percentage)
+        kitchen_setup.limit_cartesian_velocity(u'odom_combined', u'base_footprint', max_linear_velocity=0.1,
                                                        max_angular_velocity=0.2)
         kitchen_setup.send_and_check_goal()
 
-        kitchen_setup.add_json_goal(u'OpenDoor',
+        kitchen_setup.set_json_goal(u'OpenDoor',
                                     tip_link=kitchen_setup.r_tip,
                                     object_name=u'kitchen',
                                     object_link_name=handle_name,
                                     angle_goal=1.5)
         kitchen_setup.allow_all_collisions()
-        kitchen_setup.add_json_goal(u'AvoidJointLimits', percentage=percentage)
+        kitchen_setup.set_json_goal(u'AvoidJointLimits', percentage=percentage)
         kitchen_setup.send_and_check_goal()
         kitchen_setup.set_kitchen_js({u'iai_fridge_door_joint': 1.5})
 
-        kitchen_setup.add_json_goal(u'OpenDoor',
+        kitchen_setup.set_json_goal(u'OpenDoor',
                                     tip_link=kitchen_setup.r_tip,
                                     object_name=u'kitchen',
                                     object_link_name=handle_name,
                                     angle_goal=0)
         kitchen_setup.allow_all_collisions()
-        kitchen_setup.add_json_goal(u'AvoidJointLimits', percentage=percentage)
+        kitchen_setup.set_json_goal(u'AvoidJointLimits', percentage=percentage)
         kitchen_setup.send_and_check_goal()
         kitchen_setup.set_kitchen_js({u'iai_fridge_door_joint': 0})
 
@@ -878,7 +878,7 @@ class TestConstraints(object):
         tip_grasp_axis.header.frame_id = kitchen_setup.r_tip
         tip_grasp_axis.vector.z = 1
 
-        kitchen_setup.add_json_goal(u'GraspBar',
+        kitchen_setup.set_json_goal(u'GraspBar',
                                     root_link=kitchen_setup.default_root,
                                     tip_link=kitchen_setup.r_tip,
                                     tip_grasp_axis=tip_grasp_axis,
@@ -896,7 +896,7 @@ class TestConstraints(object):
         kitchen_setup.allow_all_collisions()
         kitchen_setup.send_and_check_goal()
 
-        kitchen_setup.add_json_goal(u'Open',
+        kitchen_setup.set_json_goal(u'Open',
                                     tip_link=kitchen_setup.r_tip,
                                     object_name=u'kitchen',
                                     object_link_name=handle_name)
@@ -905,7 +905,7 @@ class TestConstraints(object):
         kitchen_setup.send_and_check_goal()
         kitchen_setup.set_kitchen_js({u'iai_fridge_door_joint': np.pi / 2})
 
-        kitchen_setup.add_json_goal(u'Close',
+        kitchen_setup.set_json_goal(u'Close',
                                     tip_link=kitchen_setup.r_tip,
                                     object_name=u'kitchen',
                                     object_link_name=handle_name)
@@ -948,7 +948,7 @@ class TestConstraints(object):
         kitchen_setup.allow_all_collisions()
         kitchen_setup.send_and_check_goal()
 
-        kitchen_setup.add_json_goal(u'Close',
+        kitchen_setup.set_json_goal(u'Close',
                                     tip_link=elbow,
                                     object_name=u'kitchen',
                                     object_link_name=handle_name)
@@ -974,7 +974,7 @@ class TestConstraints(object):
         tip_grasp_axis.header.frame_id = kitchen_setup.l_tip
         tip_grasp_axis.vector.z = 1
 
-        kitchen_setup.add_json_goal(u'GraspBar',
+        kitchen_setup.set_json_goal(u'GraspBar',
                                     root_link=kitchen_setup.default_root,
                                     tip_link=kitchen_setup.l_tip,
                                     tip_grasp_axis=tip_grasp_axis,
@@ -996,7 +996,7 @@ class TestConstraints(object):
 
         kitchen_setup.send_and_check_goal()
 
-        kitchen_setup.add_json_goal(u'OpenDoor',
+        kitchen_setup.set_json_goal(u'OpenDoor',
                                     tip_link=kitchen_setup.l_tip,
                                     object_name=u'kitchen',
                                     object_link_name=handle_name,
@@ -1005,7 +1005,7 @@ class TestConstraints(object):
         kitchen_setup.send_and_check_goal()
         kitchen_setup.set_kitchen_js({u'oven_area_oven_door_joint': goal_angle})
 
-        kitchen_setup.add_json_goal(u'OpenDoor',
+        kitchen_setup.set_json_goal(u'OpenDoor',
                                     tip_link=kitchen_setup.l_tip,
                                     object_name=u'kitchen',
                                     object_link_name=handle_name,
@@ -1041,7 +1041,7 @@ class TestConstraints(object):
         tip_grasp_axis.header.frame_id = hand
         tip_grasp_axis.vector.z = 1
 
-        kitchen_setup.add_json_goal(u'GraspBar',
+        kitchen_setup.set_json_goal(u'GraspBar',
                                     root_link=kitchen_setup.default_root,
                                     tip_link=hand,
                                     tip_grasp_axis=tip_grasp_axis,
@@ -1063,7 +1063,7 @@ class TestConstraints(object):
 
         kitchen_setup.send_and_check_goal()
 
-        kitchen_setup.add_json_goal(u'Open',
+        kitchen_setup.set_json_goal(u'Open',
                                     tip_link=hand,
                                     object_name=u'kitchen',
                                     object_link_name=handle_name,
@@ -1074,7 +1074,7 @@ class TestConstraints(object):
         kitchen_setup.send_and_check_goal()
         kitchen_setup.set_kitchen_js({u'sink_area_dish_washer_door_joint': goal_angle})
 
-        kitchen_setup.add_json_goal(u'Close',
+        kitchen_setup.set_json_goal(u'Close',
                                     tip_link=hand,
                                     object_name=u'kitchen',
                                     object_link_name=handle_name)
@@ -1098,7 +1098,7 @@ class TestConstraints(object):
         tip_grasp_axis.header.frame_id = kitchen_setup.r_tip
         tip_grasp_axis.vector.z = 1
 
-        kitchen_setup.wrapper.grasp_bar(root_link=kitchen_setup.default_root,
+        kitchen_setup.grasp_bar(root_link=kitchen_setup.default_root,
                                     tip_link=kitchen_setup.r_tip,
                                     tip_grasp_axis=tip_grasp_axis,
                                     bar_center=bar_center,
@@ -1125,7 +1125,7 @@ class TestConstraints(object):
         tip_grasp_axis.header.frame_id = kitchen_setup.l_tip
         tip_grasp_axis.vector.z = 1
 
-        kitchen_setup.add_json_goal(u'GraspBar',
+        kitchen_setup.set_json_goal(u'GraspBar',
                                     root_link=kitchen_setup.default_root,
                                     tip_link=kitchen_setup.l_tip,
                                     tip_grasp_axis=tip_grasp_axis,
@@ -1146,7 +1146,7 @@ class TestConstraints(object):
         # kitchen_setup.allow_all_collisions()
         kitchen_setup.send_and_check_goal()
 
-        kitchen_setup.add_json_goal(u'Open',
+        kitchen_setup.set_json_goal(u'Open',
                                     tip_link=kitchen_setup.l_tip,
                                     object_name=u'kitchen',
                                     object_link_name=handle_name)
@@ -1156,7 +1156,7 @@ class TestConstraints(object):
         kitchen_setup.set_kitchen_js({u'sink_area_left_middle_drawer_main_joint': 0.48})
 
         # Close drawer partially
-        kitchen_setup.add_json_goal(u'OpenDrawer',
+        kitchen_setup.set_json_goal(u'OpenDrawer',
                                     tip_link=kitchen_setup.l_tip,
                                     object_name=u'kitchen',
                                     object_link_name=handle_name,
@@ -1166,7 +1166,7 @@ class TestConstraints(object):
         # Update kitchen object
         kitchen_setup.set_kitchen_js({u'sink_area_left_middle_drawer_main_joint': 0.2})
 
-        kitchen_setup.add_json_goal(u'Close',
+        kitchen_setup.set_json_goal(u'Close',
                                     tip_link=kitchen_setup.l_tip,
                                     object_name=u'kitchen',
                                     object_link_name=handle_name)
@@ -1386,7 +1386,7 @@ class TestCartGoals(object):
         kitchen_setup.set_cart_goal(r_goal, kitchen_setup.r_tip, weight=WEIGHT_BELOW_CA)
         # kitchen_setup.allow_collision([], tray_name, [])
         # kitchen_setup.allow_all_collisions()
-        kitchen_setup.add_json_goal(u'CartesianVelocityLimit',
+        kitchen_setup.set_json_goal(u'CartesianVelocityLimit',
                                     root_link=kitchen_setup.default_root,
                                     tip_link=u'base_footprint',
                                     max_linear_velocity=0.1,
@@ -1469,7 +1469,7 @@ class TestCartGoals(object):
         pocky_pose_setup.set_and_check_cart_goal(p, pocky_pose_setup.r_tip, pocky_pose_setup.default_root,
                                                  expected_error_codes=[MoveResult.SHAKING])
 
-        # box_setup.wrapper.avoid_collision()
+        # box_setup.avoid_collision()
 
         # collision_entry = CollisionEntry()
         # collision_entry.type = CollisionEntry.AVOID_COLLISION
@@ -1494,10 +1494,10 @@ class TestCartGoals(object):
         p.pose.position = Point(0, 0, 0)
         p.pose.orientation = Quaternion(0, 0, 0, 1)
         zero_pose.set_cart_goal(deepcopy(p), u'base_footprint')
-        zero_pose.add_waypoint()
+        zero_pose.add_cmd()
         p.pose.position.x += 1
         zero_pose.set_cart_goal(deepcopy(p), u'base_footprint')
-        zero_pose.add_waypoint()
+        zero_pose.add_cmd()
         p.pose.position.x += 1
         zero_pose.set_cart_goal(p, u'base_footprint')
         result = zero_pose.send_goal_and_dont_wait(stop_after=10)
@@ -1567,7 +1567,7 @@ class TestCartGoals(object):
         p.pose.orientation = Quaternion(0, 0, 0, 1)
         zero_pose.set_cart_goal(p, zero_pose.r_tip, zero_pose.default_root)
 
-        zero_pose.add_waypoint()
+        zero_pose.add_cmd()
         p = PoseStamped()
         p.header.frame_id = zero_pose.r_tip
         p.header.stamp = rospy.get_rostime()
@@ -1575,7 +1575,7 @@ class TestCartGoals(object):
         p.pose.orientation = Quaternion(0, 0, 0, 1)
         zero_pose.set_cart_goal(p, zero_pose.r_tip, zero_pose.default_root)
 
-        zero_pose.add_waypoint()
+        zero_pose.add_cmd()
         p = PoseStamped()
         p.header.frame_id = zero_pose.r_tip
         p.header.stamp = rospy.get_rostime()
@@ -1590,9 +1590,9 @@ class TestCartGoals(object):
         :type zero_pose: PR2
         """
         zero_pose.set_joint_goal(pocky_pose)
-        zero_pose.add_waypoint()
+        zero_pose.add_cmd()
         zero_pose.set_joint_goal(pick_up_pose)
-        zero_pose.add_waypoint()
+        zero_pose.add_cmd()
         zero_pose.set_joint_goal(gaya_pose)
 
         traj = zero_pose.send_and_check_goal()
@@ -1635,9 +1635,9 @@ class TestCartGoals(object):
         :type zero_pose: PR2
         """
         zero_pose.set_joint_goal(pocky_pose)
-        zero_pose.add_waypoint()
-        zero_pose.add_json_goal(u'muh')
-        zero_pose.add_waypoint()
+        zero_pose.add_cmd()
+        zero_pose.set_json_goal(u'muh')
+        zero_pose.add_cmd()
         zero_pose.set_joint_goal(gaya_pose)
 
         traj = zero_pose.send_and_check_goal(expected_error_codes=[MoveResult.SUCCESS,
@@ -1670,10 +1670,10 @@ class TestCartGoals(object):
         """
         :type zero_pose: PR2
         """
-        zero_pose.add_json_goal(u'muh')
-        zero_pose.add_waypoint()
+        zero_pose.set_json_goal(u'muh')
+        zero_pose.add_cmd()
         zero_pose.set_joint_goal(pocky_pose)
-        zero_pose.add_waypoint()
+        zero_pose.add_cmd()
         zero_pose.set_joint_goal(gaya_pose)
 
         traj = zero_pose.send_and_check_goal(expected_error_codes=[MoveResult.UNKNOWN_CONSTRAINT,
@@ -1707,10 +1707,10 @@ class TestCartGoals(object):
         :type zero_pose: PR2
         """
         zero_pose.set_joint_goal(pocky_pose)
-        zero_pose.add_waypoint()
+        zero_pose.add_cmd()
         zero_pose.set_joint_goal(gaya_pose)
-        zero_pose.add_waypoint()
-        zero_pose.add_json_goal(u'muh')
+        zero_pose.add_cmd()
+        zero_pose.set_json_goal(u'muh')
 
         traj = zero_pose.send_and_check_goal(expected_error_codes=[MoveResult.SUCCESS,
                                                                    MoveResult.SUCCESS,
@@ -1743,9 +1743,9 @@ class TestCartGoals(object):
         :type zero_pose: PR2
         """
         zero_pose.set_joint_goal(pocky_pose)
-        zero_pose.add_waypoint()
-        zero_pose.add_json_goal(u'muh')
-        zero_pose.add_waypoint()
+        zero_pose.add_cmd()
+        zero_pose.set_json_goal(u'muh')
+        zero_pose.add_cmd()
         zero_pose.set_joint_goal(gaya_pose)
 
         traj = zero_pose.send_and_check_goal(expected_error_codes=[MoveResult.SUCCESS,
@@ -1767,7 +1767,7 @@ class TestCartGoals(object):
         """
         :type zero_pose: PR2
         """
-        zero_pose.add_json_goal(u'muh')
+        zero_pose.set_json_goal(u'muh')
         zero_pose.send_and_check_goal(expected_error_codes=[MoveResult.UNKNOWN_CONSTRAINT, ],
                                       goal_type=MoveGoal.PLAN_AND_EXECUTE_AND_SKIP_FAILURES)
 
@@ -2060,7 +2060,7 @@ class TestCollisionAvoidanceGoals(object):
 
         map_T_cart_goal = tf.kdl_to_pose_stamped(map_T_odom * tf.pose_to_kdl(wrong_odom_T_goal.pose), u'map')
 
-        kitchen_setup.add_json_goal(u'AvoidJointLimits', percentage=40)
+        kitchen_setup.set_json_goal(u'AvoidJointLimits', percentage=40)
         kitchen_setup.set_and_check_cart_goal(map_T_cart_goal, kitchen_setup.r_tip)
 
     def test_bug2020_09_08_09_09_53_dump(self, kitchen_setup):
@@ -2208,7 +2208,7 @@ class TestCollisionAvoidanceGoals(object):
 
         map_T_cart_goal = tf.kdl_to_pose_stamped(map_T_odom * tf.pose_to_kdl(wrong_odom_T_goal.pose), u'map')
 
-        kitchen_setup.add_json_goal(u'AvoidJointLimits', percentage=40)
+        kitchen_setup.set_json_goal(u'AvoidJointLimits', percentage=40)
         kitchen_setup.avoid_all_collisions(0.1)
         kitchen_setup.allow_collision([
             "r_gripper_l_finger_tip_link",
@@ -2375,7 +2375,7 @@ class TestCollisionAvoidanceGoals(object):
 
         map_T_cart_goal = tf.kdl_to_pose_stamped(map_T_odom * tf.pose_to_kdl(wrong_odom_T_goal.pose), u'map')
 
-        kitchen_setup.add_json_goal(u'AvoidJointLimits', percentage=40)
+        kitchen_setup.set_json_goal(u'AvoidJointLimits', percentage=40)
         # kitchen_setup.avoid_all_collisions(0.05)
         kitchen_setup.allow_collision([
             "r_gripper_l_finger_tip_link",
@@ -2542,9 +2542,9 @@ class TestCollisionAvoidanceGoals(object):
 
         map_T_cart_goal = tf.kdl_to_pose_stamped(map_T_odom * tf.pose_to_kdl(wrong_odom_T_goal.pose), u'map')
 
-        kitchen_setup.add_json_goal(u'AvoidJointLimits', percentage=40)
+        kitchen_setup.set_json_goal(u'AvoidJointLimits', percentage=40)
         kitchen_setup.avoid_all_collisions(0.1)
-        kitchen_setup.add_json_goal(u'CartesianVelocityLimit',
+        kitchen_setup.set_json_goal(u'CartesianVelocityLimit',
                                     root_link=u'odom_combined',
                                     tip_link=u'base_footprint',
                                     max_linear_velocity=0.1,
@@ -2671,9 +2671,9 @@ class TestCollisionAvoidanceGoals(object):
 
         map_T_cart_goal = tf.kdl_to_pose_stamped(map_T_odom * tf.pose_to_kdl(wrong_odom_T_goal.pose), u'map')
 
-        kitchen_setup.add_json_goal(u'AvoidJointLimits', percentage=40)
+        kitchen_setup.set_json_goal(u'AvoidJointLimits', percentage=40)
         # kitchen_setup.avoid_all_collisions(0.1)
-        kitchen_setup.add_json_goal(u'CartesianVelocityLimit',
+        kitchen_setup.set_json_goal(u'CartesianVelocityLimit',
                                     root_link=u'odom_combined',
                                     tip_link=u'base_footprint',
                                     max_linear_velocity=0.05,
@@ -2803,7 +2803,7 @@ class TestCollisionAvoidanceGoals(object):
                                  size=[0.0695257345835, 0.0704464276632, 0.199114735921],
                                  frame_id=tip, pose=box_pose)
 
-        kitchen_setup.add_json_goal(u'CartesianVelocityLimit',
+        kitchen_setup.set_json_goal(u'CartesianVelocityLimit',
                                     root_link=u'base_footprint',
                                     tip_link=tip,
                                     max_linear_velocity=0.05,
@@ -2935,7 +2935,7 @@ class TestCollisionAvoidanceGoals(object):
                                  size=[0.0695257345835, 0.0704464276632, 0.199114735921],
                                  frame_id=tip, pose=box_pose)
 
-        kitchen_setup.add_json_goal(u'CartesianVelocityLimit',
+        kitchen_setup.set_json_goal(u'CartesianVelocityLimit',
                                     root_link=u'base_footprint',
                                     tip_link='l_wrist_roll_link',
                                     max_linear_velocity=0.05,
@@ -2944,7 +2944,7 @@ class TestCollisionAvoidanceGoals(object):
                                     # weight=WEIGHT_BELOW_CA,
                                     )
 
-        kitchen_setup.add_json_goal(u'CartesianVelocityLimit',
+        kitchen_setup.set_json_goal(u'CartesianVelocityLimit',
                                     root_link=u'base_footprint',
                                     tip_link='r_wrist_roll_link',
                                     max_linear_velocity=0.05,
@@ -3092,7 +3092,7 @@ class TestCollisionAvoidanceGoals(object):
                                  size=[0.0695257345835, 0.0704464276632, 0.199114735921],
                                  frame_id=tip, pose=box_pose)
 
-        kitchen_setup.add_json_goal(u'CartesianVelocityLimit',
+        kitchen_setup.set_json_goal(u'CartesianVelocityLimit',
                                     root_link=u'odom_combined',
                                     # root_link=u'base_footprint',
                                     tip_link='l_wrist_roll_link',
@@ -3100,7 +3100,7 @@ class TestCollisionAvoidanceGoals(object):
                                     max_angular_velocity=0.25,
                                     )
 
-        kitchen_setup.add_json_goal(u'CartesianVelocityLimit',
+        kitchen_setup.set_json_goal(u'CartesianVelocityLimit',
                                     root_link=u'odom_combined',
                                     # root_link=u'base_footprint',
                                     tip_link='r_wrist_roll_link',
@@ -3292,9 +3292,9 @@ class TestCollisionAvoidanceGoals(object):
         # base_goal.pose.orientation.w = 1
         # kitchen_setup.move_base(base_goal)
 
-        kitchen_setup.add_json_goal(u'AvoidJointLimits', percentage=40)
+        kitchen_setup.set_json_goal(u'AvoidJointLimits', percentage=40)
 
-        kitchen_setup.add_json_goal(u'CartesianVelocityLimit',
+        kitchen_setup.set_json_goal(u'CartesianVelocityLimit',
                                     root_link=u'odom_combined',
                                     tip_link='base_footprint',
                                     max_linear_velocity=0.05,
@@ -3304,7 +3304,7 @@ class TestCollisionAvoidanceGoals(object):
         avoidance_hint.header.frame_id = u'base_footprint'
         avoidance_hint.vector.y = 1
 
-        kitchen_setup.add_json_goal(u'CollisionAvoidanceHint',
+        kitchen_setup.set_json_goal(u'CollisionAvoidanceHint',
                                     link_name=u'base_link',
                                     max_threshold=0.05,
                                     spring_threshold=0.1,
@@ -3473,9 +3473,9 @@ class TestCollisionAvoidanceGoals(object):
         # base_goal.pose.orientation.w = 1
         # kitchen_setup.move_base(base_goal)
 
-        kitchen_setup.add_json_goal(u'AvoidJointLimits', percentage=40)
+        kitchen_setup.set_json_goal(u'AvoidJointLimits', percentage=40)
 
-        kitchen_setup.add_json_goal(u'CartesianVelocityLimit',
+        kitchen_setup.set_json_goal(u'CartesianVelocityLimit',
                                     root_link=u'odom_combined',
                                     tip_link='base_footprint',
                                     max_linear_velocity=0.05,
@@ -3619,8 +3619,8 @@ class TestCollisionAvoidanceGoals(object):
         kitchen_setup.add_mesh(u'bowl_1',
                                path=u'package://giskardpy/test/urdfs/meshes/cup_11.obj',
                                pose=box_pose)
-        kitchen_setup.attach_existing(u'bowl_1',
-                                      frame_id=tip)
+        kitchen_setup.attach_object(u'bowl_1',
+                                    frame_id=tip)
 
         map_T_cart_goal = convert_dictionary_to_ros_message(u'geometry_msgs/PoseStamped',
                                                             {"header": {"stamp": {"secs": 1600990649,
@@ -3638,14 +3638,14 @@ class TestCollisionAvoidanceGoals(object):
                                                                    "frame_id": "base_footprint",
                                                                    "seq": 0},
                                                         "point": {"x": 1.0, "y": 0.0, "z": 0.0}})
-        kitchen_setup.add_json_goal(u'Pointing',
+        kitchen_setup.set_json_goal(u'Pointing',
                                     root_link=u'base_footprint',
                                     tip_link=u'narrow_stereo_optical_frame',
                                     goal_point=goal_point)
 
         # kitchen_setup.add_json_goal(u'AvoidJointLimits', percentage=40)
 
-        kitchen_setup.add_json_goal(u'CartesianVelocityLimit',
+        kitchen_setup.set_json_goal(u'CartesianVelocityLimit',
                                     root_link=u'odom_combined',
                                     tip_link='base_footprint',
                                     max_linear_velocity=0.25,
@@ -3655,7 +3655,7 @@ class TestCollisionAvoidanceGoals(object):
         avoidance_hint = Vector3Stamped()
         avoidance_hint.header.frame_id = u'base_footprint'
         avoidance_hint.vector.y = 1
-        kitchen_setup.add_json_goal(u'CollisionAvoidanceHint',
+        kitchen_setup.set_json_goal(u'CollisionAvoidanceHint',
                                     link_name=u'base_link',
                                     max_threshold=0.05,
                                     spring_threshold=0.1,
@@ -3835,8 +3835,8 @@ class TestCollisionAvoidanceGoals(object):
 
         map_T_cart_goal = tf.kdl_to_pose_stamped(map_T_odom * tf.pose_to_kdl(wrong_odom_T_goal.pose), u'map')
 
-        kitchen_setup.add_json_goal(u'AvoidJointLimits', percentage=40)
-        kitchen_setup.add_json_goal(u'CartesianVelocityLimit',
+        kitchen_setup.set_json_goal(u'AvoidJointLimits', percentage=40)
+        kitchen_setup.set_json_goal(u'CartesianVelocityLimit',
                                     root_link=u'odom_combined',
                                     tip_link='base_footprint',
                                     max_linear_velocity=0.05,
@@ -3991,9 +3991,9 @@ class TestCollisionAvoidanceGoals(object):
 
         map_T_cart_goal = tf.kdl_to_pose_stamped(map_T_odom * tf.pose_to_kdl(wrong_odom_T_goal.pose), u'map')
 
-        kitchen_setup.add_json_goal(u'AvoidJointLimits', percentage=40)
+        kitchen_setup.set_json_goal(u'AvoidJointLimits', percentage=40)
         # kitchen_setup.avoid_all_collisions(0.1)
-        kitchen_setup.add_json_goal(u'CartesianVelocityLimit',
+        kitchen_setup.set_json_goal(u'CartesianVelocityLimit',
                                     root_link=u'odom_combined',
                                     tip_link=u'base_footprint',
                                     max_linear_velocity=0.05,
@@ -4109,7 +4109,7 @@ class TestCollisionAvoidanceGoals(object):
         avoidance_hint = Vector3Stamped()
         avoidance_hint.header.frame_id = 'map'
         avoidance_hint.vector.y = -1
-        kitchen_setup.add_json_goal(u'CollisionAvoidanceHint',
+        kitchen_setup.set_json_goal(u'CollisionAvoidanceHint',
                                     link_name=u'base_link',
                                     max_threshold=0.3,
                                     # spring_threshold=0.5,
@@ -4118,7 +4118,7 @@ class TestCollisionAvoidanceGoals(object):
                                     link_b=u'kitchen_island',
                                     weight=WEIGHT_COLLISION_AVOIDANCE,
                                     avoidance_hint=avoidance_hint)
-        kitchen_setup.add_json_goal(u'CartesianVelocityLimit',
+        kitchen_setup.set_json_goal(u'CartesianVelocityLimit',
                                     root_link=u'odom_combined',
                                     tip_link=u'base_footprint',
                                     max_linear_velocity=0.5,
@@ -4236,7 +4236,7 @@ class TestCollisionAvoidanceGoals(object):
         avoidance_hint = Vector3Stamped()
         avoidance_hint.header.frame_id = 'map'
         avoidance_hint.vector.y = -1
-        kitchen_setup.add_json_goal(u'CollisionAvoidanceHint',
+        kitchen_setup.set_json_goal(u'CollisionAvoidanceHint',
                                     link_name=u'base_link',
                                     max_threshold=0.25,
                                     spring_threshold=0.3,
@@ -4245,7 +4245,7 @@ class TestCollisionAvoidanceGoals(object):
                                     link_b=u'kitchen_island',
                                     weight=WEIGHT_COLLISION_AVOIDANCE,
                                     avoidance_hint=avoidance_hint)
-        kitchen_setup.add_json_goal(u'CartesianVelocityLimit',
+        kitchen_setup.set_json_goal(u'CartesianVelocityLimit',
                                     root_link=u'odom_combined',
                                     tip_link=u'base_footprint',
                                     max_linear_velocity=0.5,
@@ -4360,7 +4360,7 @@ class TestCollisionAvoidanceGoals(object):
         avoidance_hint = Vector3Stamped()
         avoidance_hint.header.frame_id = 'map'
         avoidance_hint.vector.y = -1
-        kitchen_setup.add_json_goal(u'CollisionAvoidanceHint',
+        kitchen_setup.set_json_goal(u'CollisionAvoidanceHint',
                                     link_name=u'base_link',
                                     max_threshold=0.25,
                                     spring_threshold=0.3,
@@ -4369,7 +4369,7 @@ class TestCollisionAvoidanceGoals(object):
                                     link_b=u'kitchen_island',
                                     weight=WEIGHT_COLLISION_AVOIDANCE,
                                     avoidance_hint=avoidance_hint)
-        kitchen_setup.add_json_goal(u'CartesianVelocityLimit',
+        kitchen_setup.set_json_goal(u'CartesianVelocityLimit',
                                     root_link=u'odom_combined',
                                     tip_link=u'base_footprint',
                                     max_linear_velocity=0.5,
@@ -4501,7 +4501,7 @@ class TestCollisionAvoidanceGoals(object):
         avoidance_hint = Vector3Stamped()
         avoidance_hint.header.frame_id = 'map'
         avoidance_hint.vector.y = -1
-        kitchen_setup.add_json_goal(u'CollisionAvoidanceHint',
+        kitchen_setup.set_json_goal(u'CollisionAvoidanceHint',
                                     link_name=u'base_link',
                                     max_threshold=0.25,
                                     spring_threshold=0.3,
@@ -4510,7 +4510,7 @@ class TestCollisionAvoidanceGoals(object):
                                     link_b=u'kitchen_island',
                                     weight=WEIGHT_COLLISION_AVOIDANCE,
                                     avoidance_hint=avoidance_hint)
-        kitchen_setup.add_json_goal(u'CartesianVelocityLimit',
+        kitchen_setup.set_json_goal(u'CartesianVelocityLimit',
                                     root_link=u'odom_combined',
                                     tip_link=u'base_footprint',
                                     max_linear_velocity=0.5,
@@ -4675,7 +4675,7 @@ class TestCollisionAvoidanceGoals(object):
         avoidance_hint = Vector3Stamped()
         avoidance_hint.header.frame_id = 'map'
         avoidance_hint.vector.y = -1
-        kitchen_setup.add_json_goal(u'CollisionAvoidanceHint',
+        kitchen_setup.set_json_goal(u'CollisionAvoidanceHint',
                                     link_name=u'base_link',
                                     max_threshold=0.25,
                                     spring_threshold=0.3,
@@ -4684,7 +4684,7 @@ class TestCollisionAvoidanceGoals(object):
                                     link_b=u'kitchen_island',
                                     weight=WEIGHT_COLLISION_AVOIDANCE,
                                     avoidance_hint=avoidance_hint)
-        kitchen_setup.add_json_goal(u'CartesianVelocityLimit',
+        kitchen_setup.set_json_goal(u'CartesianVelocityLimit',
                                     root_link=u'odom_combined',
                                     tip_link=u'base_footprint',
                                     max_linear_velocity=0.5,
@@ -4882,7 +4882,7 @@ class TestCollisionAvoidanceGoals(object):
         avoidance_hint = Vector3Stamped()
         avoidance_hint.header.frame_id = 'map'
         avoidance_hint.vector.y = -1
-        kitchen_setup.add_json_goal(u'CollisionAvoidanceHint',
+        kitchen_setup.set_json_goal(u'CollisionAvoidanceHint',
                                     link_name=u'base_link',
                                     max_threshold=0.3,
                                     # spring_threshold=0.5,
@@ -4891,7 +4891,7 @@ class TestCollisionAvoidanceGoals(object):
                                     link_b=u'kitchen_island',
                                     weight=WEIGHT_COLLISION_AVOIDANCE,
                                     avoidance_hint=avoidance_hint)
-        kitchen_setup.add_json_goal(u'CartesianVelocityLimit',
+        kitchen_setup.set_json_goal(u'CartesianVelocityLimit',
                                     root_link=u'odom_combined',
                                     tip_link=u'base_footprint',
                                     max_linear_velocity=0.5,
@@ -5048,7 +5048,7 @@ class TestCollisionAvoidanceGoals(object):
                                                               }
                                                               )
         map_T_cart_goal = tf.kdl_to_pose_stamped(map_T_odom * tf.pose_to_kdl(wrong_odom_T_goal.pose), u'map')
-        kitchen_setup.add_json_goal(u'CartesianVelocityLimit',
+        kitchen_setup.set_json_goal(u'CartesianVelocityLimit',
                                     root_link=u'odom_combined',
                                     tip_link=u'base_footprint',
                                     max_linear_velocity=0.1,
@@ -5183,7 +5183,7 @@ class TestCollisionAvoidanceGoals(object):
         avoidance_hint = Vector3Stamped()
         avoidance_hint.header.frame_id = 'map'
         avoidance_hint.vector.y = -1
-        kitchen_setup.add_json_goal(u'CollisionAvoidanceHint',
+        kitchen_setup.set_json_goal(u'CollisionAvoidanceHint',
                                     link_name=u'base_footprint',
                                     max_threshold=0.3,
                                     max_linear_velocity=1,
@@ -5191,7 +5191,7 @@ class TestCollisionAvoidanceGoals(object):
                                     link_b=u'kitchen_island',
                                     weight=WEIGHT_COLLISION_AVOIDANCE,
                                     avoidance_hint=avoidance_hint)
-        kitchen_setup.add_json_goal(u'CartesianVelocityLimit',
+        kitchen_setup.set_json_goal(u'CartesianVelocityLimit',
                                     root_link=u'odom_combined',
                                     tip_link=u'base_footprint',
                                     max_linear_velocity=0.5,
@@ -5238,7 +5238,7 @@ class TestCollisionAvoidanceGoals(object):
         kitchen_setup.check_cart_goal(kitchen_setup.r_tip, r_goal)
 
         kitchen_setup.detach_object('box')
-        kitchen_setup.attach_existing('box', kitchen_setup.r_tip)
+        kitchen_setup.attach_object('box', kitchen_setup.r_tip)
 
         r_goal2 = PoseStamped()
         r_goal2.header.frame_id = 'box'
@@ -5403,7 +5403,7 @@ class TestCollisionAvoidanceGoals(object):
         p.pose.orientation.w = 1
         zero_pose.add_box(pocky, pose=p)
         for i in range(10):
-            zero_pose.attach_existing(pocky, zero_pose.r_tip)
+            zero_pose.attach_object(pocky, zero_pose.r_tip)
             zero_pose.detach_object(pocky)
         zero_pose.remove_object(pocky)
 
@@ -5425,7 +5425,7 @@ class TestCollisionAvoidanceGoals(object):
         p.pose.position = Point(0.05, 0, 0)
         p.pose.orientation = Quaternion(0., 0., 0.47942554, 0.87758256)
         zero_pose.add_box(pocky, [0.1, 0.02, 0.02], pose=p)
-        zero_pose.attach_existing(pocky, frame_id=zero_pose.r_tip)
+        zero_pose.attach_object(pocky, frame_id=zero_pose.r_tip)
         relative_pose = zero_pose.get_robot().get_fk_pose(zero_pose.r_tip, pocky).pose
         compare_poses(p.pose, relative_pose)
 
@@ -5439,11 +5439,11 @@ class TestCollisionAvoidanceGoals(object):
         p.pose.position = Point(1.2, 0, 1.6)
         p.pose.orientation = Quaternion(0.0, 0.0, 0.47942554, 0.87758256)
         zero_pose.add_box(object_name, pose=p)
-        zero_pose.attach_existing(object_name, frame_id=zero_pose.r_tip)
+        zero_pose.attach_object(object_name, frame_id=zero_pose.r_tip)
         zero_pose.detach_object(object_name)
         zero_pose.remove_object(object_name)
         zero_pose.add_box(object_name, pose=p)
-        assert zero_pose.wrapper.get_attached_objects().object_names == []
+        assert zero_pose.get_attached_objects().object_names == []
 
     def test_attach_existing_box2(self, zero_pose):
         """
@@ -5455,7 +5455,7 @@ class TestCollisionAvoidanceGoals(object):
         old_p.pose.position = Point(0.05, 0, 0)
         old_p.pose.orientation = Quaternion(0., 0., 0.47942554, 0.87758256)
         zero_pose.add_box(pocky, [0.1, 0.02, 0.02], pose=old_p)
-        zero_pose.attach_existing(pocky, frame_id=zero_pose.r_tip)
+        zero_pose.attach_object(pocky, frame_id=zero_pose.r_tip)
         relative_pose = zero_pose.get_robot().get_fk_pose(zero_pose.r_tip, pocky).pose
         compare_poses(old_p.pose, relative_pose)
 
@@ -5491,7 +5491,7 @@ class TestCollisionAvoidanceGoals(object):
         old_p.pose.position = Point(0.05, 0, 0)
         old_p.pose.orientation = Quaternion(0., 0., 0.47942554, 0.87758256)
         zero_pose.add_box(pocky, [0.1, 0.02, 0.02], pose=old_p)
-        zero_pose.attach_existing(pocky, frame_id=zero_pose.r_tip)
+        zero_pose.attach_object(pocky, frame_id=zero_pose.r_tip)
         relative_pose = zero_pose.get_robot().get_fk_pose(zero_pose.r_tip, pocky).pose
         compare_poses(old_p.pose, relative_pose)
 
@@ -5535,7 +5535,7 @@ class TestCollisionAvoidanceGoals(object):
         :type zero_pose: PR2
         """
         req = UpdateWorldRequest(42, WorldBody(), True, PoseStamped())
-        assert zero_pose.wrapper._update_world_srv.call(req).error_codes == UpdateWorldResponse.INVALID_OPERATION
+        assert zero_pose._update_world_srv.call(req).error_codes == UpdateWorldResponse.INVALID_OPERATION
 
     def test_missing_body_error(self, zero_pose):
         """
@@ -5549,7 +5549,7 @@ class TestCollisionAvoidanceGoals(object):
         """
         req = UpdateWorldRequest(UpdateWorldRequest.ADD, WorldBody(type=WorldBody.PRIMITIVE_BODY,
                                                                    shape=SolidPrimitive(type=42)), True, PoseStamped())
-        assert zero_pose.wrapper._update_world_srv.call(req).error_codes == UpdateWorldResponse.CORRUPT_SHAPE_ERROR
+        assert zero_pose._update_world_srv.call(req).error_codes == UpdateWorldResponse.CORRUPT_SHAPE_ERROR
 
     def test_unsupported_options(self, kitchen_setup):
         """
@@ -5564,7 +5564,7 @@ class TestCollisionAvoidanceGoals(object):
         wb.type = WorldBody.URDF_BODY
 
         req = UpdateWorldRequest(UpdateWorldRequest.ADD, wb, True, pose)
-        assert kitchen_setup.wrapper._update_world_srv.call(req).error_codes == UpdateWorldResponse.UNSUPPORTED_OPTIONS
+        assert kitchen_setup._update_world_srv.call(req).error_codes == UpdateWorldResponse.UNSUPPORTED_OPTIONS
 
     def test_infeasible(self, kitchen_setup):
         """
@@ -5584,7 +5584,7 @@ class TestCollisionAvoidanceGoals(object):
         ce = CollisionEntry()
         ce.type = CollisionEntry.AVOID_COLLISION
         ce.link_bs = [u'asdf']
-        box_setup.add_collision_entries([ce])
+        box_setup.set_collision_entries([ce])
         box_setup.send_and_check_goal(expected_error_codes=[MoveResult.WORLD_ERROR])
 
     def test_unknown_robot_link(self, box_setup):
@@ -5594,7 +5594,7 @@ class TestCollisionAvoidanceGoals(object):
         ce = CollisionEntry()
         ce.type = CollisionEntry.AVOID_COLLISION
         ce.robot_links = [u'asdf']
-        box_setup.add_collision_entries([ce])
+        box_setup.set_collision_entries([ce])
         box_setup.send_and_check_goal([MoveResult.UNKNOWN_OBJECT])
 
     def test_unknown_body_b(self, box_setup):
@@ -5604,7 +5604,7 @@ class TestCollisionAvoidanceGoals(object):
         ce = CollisionEntry()
         ce.type = CollisionEntry.AVOID_COLLISION
         ce.body_b = u'asdf'
-        box_setup.add_collision_entries([ce])
+        box_setup.set_collision_entries([ce])
         box_setup.send_and_check_goal([MoveResult.UNKNOWN_OBJECT])
 
     def test_unknown_link_b(self, box_setup):
@@ -5615,7 +5615,7 @@ class TestCollisionAvoidanceGoals(object):
         ce.type = CollisionEntry.AVOID_COLLISION
         ce.body_b = u'box'
         ce.link_bs = [u'asdf']
-        box_setup.add_collision_entries([ce])
+        box_setup.set_collision_entries([ce])
         box_setup.send_and_check_goal([MoveResult.UNKNOWN_OBJECT])
 
     def test_base_link_in_collision(self, zero_pose):
@@ -5646,7 +5646,7 @@ class TestCollisionAvoidanceGoals(object):
         collision_entry.type = CollisionEntry.AVOID_COLLISION
         collision_entry.min_dist = 0.05
         collision_entry.body_b = u'muh'
-        box_setup.add_collision_entries([collision_entry])
+        box_setup.set_collision_entries([collision_entry])
 
         box_setup.send_and_check_goal([MoveResult.UNKNOWN_OBJECT])
 
@@ -5712,7 +5712,7 @@ class TestCollisionAvoidanceGoals(object):
                                   robot_links=zero_pose.get_l_gripper_links(),
                                   body_b=u'pr2',
                                   link_bs=zero_pose.get_r_forearm_links()))
-        zero_pose.add_collision_entries(ces)
+        zero_pose.set_collision_entries(ces)
 
         zero_pose.set_and_check_cart_goal(p, zero_pose.l_tip, zero_pose.default_root)
         zero_pose.check_cpi_leq(zero_pose.get_l_gripper_links(), 0.01)
@@ -5804,7 +5804,7 @@ class TestCollisionAvoidanceGoals(object):
         ce.type = CollisionEntry.AVOID_COLLISION
         ce.body_b = u'box'
         # ce.min_dist = 0.05
-        box_setup.add_collision_entries([ce])
+        box_setup.set_collision_entries([ce])
         box_setup.send_and_check_goal([MoveResult.SUCCESS])
         box_setup.check_cpi_geq(box_setup.get_l_gripper_links(), 0.048)
         box_setup.check_cpi_geq(box_setup.get_r_gripper_links(), 0.048)
@@ -5856,7 +5856,7 @@ class TestCollisionAvoidanceGoals(object):
         collision_entry.type = CollisionEntry.ALLOW_COLLISION
         collision_entry.body_b = u'box'
         collision_entry.link_bs = [u'box']
-        box_setup.wrapper.set_collision_entries([collision_entry])
+        box_setup.set_collision_entries([collision_entry])
 
         box_setup.allow_self_collision()
         box_setup.set_and_check_cart_goal(p, box_setup.r_tip, box_setup.default_root)
@@ -6041,7 +6041,7 @@ class TestCollisionAvoidanceGoals(object):
         base_pose.pose.orientation = Quaternion(*quaternion_about_axis(-np.pi / 4, [0, 0, 1]))
         kitchen_setup.set_joint_goal(gaya_pose)
         kitchen_setup.set_and_check_cart_goal(base_pose, u'base_footprint')
-        kitchen_setup.check_joint_state(gaya_pose)
+        kitchen_setup.check_current_joint_state(gaya_pose)
 
     def test_avoid_collision9(self, kitchen_setup):
         """
@@ -6056,7 +6056,7 @@ class TestCollisionAvoidanceGoals(object):
         base_pose.pose.orientation = Quaternion(*quaternion_about_axis(np.pi, [0, 0, 1]))
         kitchen_setup.set_joint_goal(gaya_pose)
         kitchen_setup.set_and_check_cart_goal(base_pose, u'base_footprint', expected_error_codes=[MoveResult.SHAKING])
-        kitchen_setup.check_joint_state(gaya_pose)
+        kitchen_setup.check_current_joint_state(gaya_pose)
 
     def test_avoid_collision8(self, kitchen_setup):
         """
@@ -6075,7 +6075,7 @@ class TestCollisionAvoidanceGoals(object):
         base_pose.pose.orientation = Quaternion(*quaternion_about_axis(-np.pi / 4, [0, 0, 1]))
         kitchen_setup.set_joint_goal(gaya_pose)
         kitchen_setup.set_and_check_cart_goal(base_pose, 'base_footprint')
-        kitchen_setup.check_joint_state(gaya_pose)
+        kitchen_setup.check_current_joint_state(gaya_pose)
 
     def test_go_around_kitchen_island(self, kitchen_setup):
         """
@@ -6097,7 +6097,7 @@ class TestCollisionAvoidanceGoals(object):
         avoidance_hint.header.frame_id = u'map'
         avoidance_hint.vector.y = -1
         kitchen_setup.avoid_all_collisions(0.1)
-        kitchen_setup.add_json_goal(u'CollisionAvoidanceHint',
+        kitchen_setup.set_json_goal(u'CollisionAvoidanceHint',
                                     link_name=u'base_link',
                                     max_threshold=0.3,
                                     spring_threshold=0.35,
@@ -6131,7 +6131,7 @@ class TestCollisionAvoidanceGoals(object):
         avoidance_hint.header.frame_id = u'map'
         avoidance_hint.vector.y = -1
         kitchen_setup.avoid_all_collisions(0.1)
-        kitchen_setup.add_json_goal(u'CollisionAvoidanceHint',
+        kitchen_setup.set_json_goal(u'CollisionAvoidanceHint',
                                     link_name=u'base_footprint',
                                     max_threshold=0.25,
                                     spring_threshold=0.3,
@@ -6166,7 +6166,7 @@ class TestCollisionAvoidanceGoals(object):
         collision_entry.type = CollisionEntry.AVOID_COLLISION
         collision_entry.min_dist = 0.05
         collision_entry.body_b = u'box'
-        pocky_pose_setup.add_collision_entries([collision_entry])
+        pocky_pose_setup.set_collision_entries([collision_entry])
 
         pocky_pose_setup.send_and_check_goal()
         pocky_pose_setup.check_cpi_geq(pocky_pose_setup.get_l_gripper_links(), 0.048)
@@ -6185,7 +6185,7 @@ class TestCollisionAvoidanceGoals(object):
         collision_entry = CollisionEntry()
         collision_entry.type = CollisionEntry.AVOID_ALL_COLLISIONS
         collision_entry.min_dist = 0.05
-        box_setup.add_collision_entries([collision_entry])
+        box_setup.set_collision_entries([collision_entry])
 
         box_setup.send_and_check_goal()
 
@@ -6205,14 +6205,14 @@ class TestCollisionAvoidanceGoals(object):
         collision_entry = CollisionEntry()
         collision_entry.type = CollisionEntry.ALLOW_ALL_COLLISIONS
         collision_entry.min_dist = 0.05
-        box_setup.add_collision_entries([collision_entry])
+        box_setup.set_collision_entries([collision_entry])
 
         box_setup.send_and_check_goal()
 
         collision_entry = CollisionEntry()
         collision_entry.type = CollisionEntry.AVOID_ALL_COLLISIONS
         collision_entry.min_dist = 0.05
-        box_setup.add_collision_entries([collision_entry])
+        box_setup.set_collision_entries([collision_entry])
 
         box_setup.send_and_check_goal()
 
@@ -6224,7 +6224,7 @@ class TestCollisionAvoidanceGoals(object):
         :type box_setup: PR2
         """
         ces = box_setup.get_allow_l_gripper(u'box')
-        box_setup.add_collision_entries(ces)
+        box_setup.set_collision_entries(ces)
         p = PoseStamped()
         p.header.frame_id = box_setup.l_tip
         p.header.stamp = rospy.get_rostime()
@@ -6412,7 +6412,7 @@ class TestCollisionAvoidanceGoals(object):
         p.pose.position.z = 0.25
         p.pose.orientation.w = 1
         zero_pose.set_and_check_cart_goal(p, zero_pose.l_tip, zero_pose.default_root)
-        zero_pose.check_joint_state(js_goal)
+        zero_pose.check_current_joint_state(js_goal)
 
         zero_pose.check_cpi_geq(zero_pose.get_l_gripper_links(), 0.048)
         zero_pose.check_cpi_geq([attached_link_name], 0.048)
@@ -6431,7 +6431,7 @@ class TestCollisionAvoidanceGoals(object):
         ce.robot_links = [pocky]
         ce.body_b = u'box'
         ces.append(ce)
-        box_setup.add_collision_entries(ces)
+        box_setup.set_collision_entries(ces)
 
         p = PoseStamped()
         p.header.frame_id = box_setup.r_tip
@@ -6448,7 +6448,7 @@ class TestCollisionAvoidanceGoals(object):
         """
         box_setup.allow_all_collisions()
         ces = box_setup.get_l_gripper_collision_entries(u'box', 0.05, CollisionEntry.AVOID_COLLISION)
-        box_setup.add_collision_entries(ces)
+        box_setup.set_collision_entries(ces)
         p = PoseStamped()
         p.header.frame_id = box_setup.l_tip
         p.header.stamp = rospy.get_rostime()
@@ -6605,7 +6605,7 @@ class TestCollisionAvoidanceGoals(object):
     #     p.header.frame_id = kitchen_setup.l_tip
     #     p.pose.position.x = 0.2
     #     p.pose.orientation.w = 1
-    #     kitchen_setup.wrapper.allow_collision(kitchen_setup.get_l_gripper_links(), u'kitchen',
+    #     kitchen_setup.allow_collision(kitchen_setup.get_l_gripper_links(), u'kitchen',
     #                                           [u'sink_area', u'sink_area_surface'])
     #     kitchen_setup.set_and_check_cart_goal(p, kitchen_setup.l_tip, kitchen_setup.default_root)
     #
@@ -6808,7 +6808,7 @@ class TestCollisionAvoidanceGoals(object):
         tip_grasp_axis.header.frame_id = kitchen_setup.l_tip
         tip_grasp_axis.vector.z = 1
 
-        kitchen_setup.add_json_goal(u'GraspBar',
+        kitchen_setup.set_json_goal(u'GraspBar',
                                     root_link=kitchen_setup.default_root,
                                     tip_link=kitchen_setup.l_tip,
                                     tip_grasp_axis=tip_grasp_axis,
@@ -6835,7 +6835,7 @@ class TestCollisionAvoidanceGoals(object):
         # kitchen_setup.allow_all_collisions()
         kitchen_setup.send_and_check_goal()
 
-        kitchen_setup.attach_existing(milk_name, kitchen_setup.l_tip)
+        kitchen_setup.attach_object(milk_name, kitchen_setup.l_tip)
         # kitchen_setup.keep_position(kitchen_setup.r_tip)
         kitchen_setup.close_l_gripper()
 
@@ -6886,7 +6886,7 @@ class TestCollisionAvoidanceGoals(object):
         # take milk out of fridge
         kitchen_setup.set_kitchen_js({u'oven_area_area_right_drawer_main_joint': 0.48})
 
-        kitchen_setup.add_json_goal(u'BasePointingForward')
+        kitchen_setup.set_json_goal(u'BasePointingForward')
 
         # spawn milk
 
@@ -6910,10 +6910,10 @@ class TestCollisionAvoidanceGoals(object):
 
         grasp_pose = tf.kdl_to_pose_stamped(drawer_T_box * box_T_r_goal_pre, drawer_frame_id)
 
-        kitchen_setup.add_json_goal(u'AvoidJointLimits', percentage=40)
+        kitchen_setup.set_json_goal(u'AvoidJointLimits', percentage=40)
         kitchen_setup.set_and_check_cart_goal(grasp_pose, tip_link=kitchen_setup.r_tip)
 
-        kitchen_setup.attach_existing(cereal_name, kitchen_setup.l_tip)
+        kitchen_setup.attach_object(cereal_name, kitchen_setup.l_tip)
         # kitchen_setup.keep_position(kitchen_setup.r_tip)
         kitchen_setup.close_l_gripper()
 
@@ -7014,7 +7014,7 @@ class TestCollisionAvoidanceGoals(object):
                                                                       [0, 0, -1, 0],
                                                                       [-1, 0, 0, 0],
                                                                       [0, 0, 0, 1]]))
-        kitchen_setup.add_json_goal(u'AvoidJointLimits', percentage=percentage)
+        kitchen_setup.set_json_goal(u'AvoidJointLimits', percentage=percentage)
         kitchen_setup.set_and_check_cart_goal(r_goal, kitchen_setup.r_tip, kitchen_setup.default_root)
 
         l_goal.pose.position.z -= .2
@@ -7023,11 +7023,11 @@ class TestCollisionAvoidanceGoals(object):
         kitchen_setup.allow_collision([CollisionEntry.ALL], cup_name, [CollisionEntry.ALL])
         kitchen_setup.set_cart_goal(l_goal, kitchen_setup.l_tip, kitchen_setup.default_root)
         kitchen_setup.set_cart_goal(r_goal, kitchen_setup.r_tip, kitchen_setup.default_root)
-        kitchen_setup.add_json_goal(u'AvoidJointLimits', percentage=percentage)
+        kitchen_setup.set_json_goal(u'AvoidJointLimits', percentage=percentage)
         kitchen_setup.send_and_check_goal()
 
-        kitchen_setup.attach_existing(bowl_name, kitchen_setup.l_tip)
-        kitchen_setup.attach_existing(cup_name, kitchen_setup.r_tip)
+        kitchen_setup.attach_object(bowl_name, kitchen_setup.l_tip)
+        kitchen_setup.attach_object(cup_name, kitchen_setup.r_tip)
 
         kitchen_setup.send_and_check_joint_goal(gaya_pose)
         base_goal = PoseStamped()
@@ -7049,7 +7049,7 @@ class TestCollisionAvoidanceGoals(object):
 
         kitchen_setup.set_cart_goal(bowl_goal, bowl_name, kitchen_setup.default_root)
         kitchen_setup.set_cart_goal(cup_goal, cup_name, kitchen_setup.default_root)
-        kitchen_setup.add_json_goal(u'AvoidJointLimits', percentage=percentage)
+        kitchen_setup.set_json_goal(u'AvoidJointLimits', percentage=percentage)
         kitchen_setup.send_and_check_goal()
 
         kitchen_setup.detach_object(bowl_name)
@@ -7096,7 +7096,7 @@ class TestCollisionAvoidanceGoals(object):
         r_goal.pose.position.x += 0.25
         r_goal.pose.orientation.w = 1
 
-        kitchen_setup.add_json_goal(u'AvoidJointLimits', percentage=percentage)
+        kitchen_setup.set_json_goal(u'AvoidJointLimits', percentage=percentage)
         kitchen_setup.set_and_check_cart_goal(r_goal, tip_link=kitchen_setup.r_tip)
 
         # spawn cup
@@ -7150,26 +7150,26 @@ class TestCollisionAvoidanceGoals(object):
                                                                       [0, -1, 0, 0],
                                                                       [-1, 0, 0, 0],
                                                                       [0, 0, 0, 1]]))
-        kitchen_setup.add_json_goal(u'AvoidJointLimits', percentage=percentage)
+        kitchen_setup.set_json_goal(u'AvoidJointLimits', percentage=percentage)
         kitchen_setup.set_and_check_cart_goal(l_goal, kitchen_setup.l_tip, kitchen_setup.default_root)
 
         l_goal.pose.position.z -= .2
         # kitchen_setup.allow_collision([CollisionEntry.ALL], spoon_name, [CollisionEntry.ALL])
         kitchen_setup.set_cart_goal(l_goal, kitchen_setup.l_tip, kitchen_setup.default_root)
-        kitchen_setup.add_json_goal(u'AvoidJointLimits', percentage=percentage)
+        kitchen_setup.set_json_goal(u'AvoidJointLimits', percentage=percentage)
         kitchen_setup.send_and_check_goal()
-        kitchen_setup.attach_existing(spoon_name, kitchen_setup.l_tip)
+        kitchen_setup.attach_object(spoon_name, kitchen_setup.l_tip)
 
         l_goal.pose.position.z += .2
         # kitchen_setup.allow_collision([CollisionEntry.ALL], spoon_name, [CollisionEntry.ALL])
         kitchen_setup.set_cart_goal(l_goal, kitchen_setup.l_tip, kitchen_setup.default_root)
-        kitchen_setup.add_json_goal(u'AvoidJointLimits', percentage=percentage)
+        kitchen_setup.set_json_goal(u'AvoidJointLimits', percentage=percentage)
         kitchen_setup.send_and_check_goal()
 
         l_goal.pose.position.z -= .2
         # kitchen_setup.allow_collision([CollisionEntry.ALL], spoon_name, [CollisionEntry.ALL])
         kitchen_setup.set_cart_goal(l_goal, kitchen_setup.l_tip, kitchen_setup.default_root)
-        kitchen_setup.add_json_goal(u'AvoidJointLimits', percentage=percentage)
+        kitchen_setup.set_json_goal(u'AvoidJointLimits', percentage=percentage)
         kitchen_setup.send_and_check_goal()
 
         kitchen_setup.send_and_check_joint_goal(gaya_pose)
@@ -7216,7 +7216,7 @@ class TestCollisionAvoidanceGoals(object):
         l_goal.pose.position.x += 0.2
         # l_goal.pose.position.z -= 0.1
         l_goal.pose.orientation.w = 1
-        kitchen_setup.add_json_goal(u'AvoidJointLimits', percentage=percentage)
+        kitchen_setup.set_json_goal(u'AvoidJointLimits', percentage=percentage)
 
         js = {
             u'r_upper_arm_roll_joint': -1.4635104674,
@@ -7268,7 +7268,7 @@ class TestCollisionAvoidanceGoals(object):
         kitchen_setup.allow_collision([], tray_name, [])
         kitchen_setup.send_and_check_goal()
 
-        kitchen_setup.attach_existing(tray_name, kitchen_setup.r_tip)
+        kitchen_setup.attach_object(tray_name, kitchen_setup.r_tip)
 
         kitchen_setup.allow_collision(robot_links=[tray_name],
                                       body_b=kitchen_setup.get_robot().get_name(),
@@ -7343,7 +7343,7 @@ class TestCollisionAvoidanceGoals(object):
         tip_grasp_axis.header.frame_id = hand
         tip_grasp_axis.vector.z = 1
 
-        kitchen_setup.add_json_goal(u'GraspBar',
+        kitchen_setup.set_json_goal(u'GraspBar',
                                     root_link=kitchen_setup.default_root,
                                     tip_link=hand,
                                     tip_grasp_axis=tip_grasp_axis,
@@ -7365,7 +7365,7 @@ class TestCollisionAvoidanceGoals(object):
 
         kitchen_setup.send_and_check_goal()
 
-        kitchen_setup.add_json_goal(u'Open',
+        kitchen_setup.set_json_goal(u'Open',
                                     tip_link=hand,
                                     object_name=u'kitchen',
                                     object_link_name=handle_name,
@@ -7392,7 +7392,7 @@ class TestCollisionAvoidanceGoals(object):
         tip_grasp_axis.header.frame_id = hand
         tip_grasp_axis.vector.z = 1
 
-        kitchen_setup.add_json_goal(u'GraspBar',
+        kitchen_setup.set_json_goal(u'GraspBar',
                                     root_link=kitchen_setup.default_root,
                                     tip_link=hand,
                                     tip_grasp_axis=tip_grasp_axis,
@@ -7461,7 +7461,7 @@ class TestReachability():
         pose.pose.position.z = 1.2
         pose.header.frame_id = 'map'
         pose.pose.orientation.w = 1
-        zero_pose.set_translation_goal(root_link='odom_combined', tip_link='r_gripper_tool_frame', goal_pose=pose)
+        zero_pose.set_translation_goal(goal_pose=pose, tip_link='r_gripper_tool_frame', root_link='odom_combined')
         js = {}
         js['r_shoulder_lift_joint'] = 1.0  # soft lower -0.3536 soft upper 1.2963
         js['r_elbow_flex_joint'] = -0.2  # soft lower -2.1213 soft upper -0.15
@@ -7475,13 +7475,13 @@ class TestReachability():
         pose.pose.position.z = 1
         pose.header.frame_id = 'map'
         pose.pose.orientation.w = 1
-        zero_pose.set_translation_goal(root_link='odom_combined', tip_link='r_gripper_tool_frame', goal_pose=pose)
+        zero_pose.set_translation_goal(goal_pose=pose, tip_link='r_gripper_tool_frame', root_link='odom_combined')
         pose2 = PoseStamped()
         pose2.pose.position.y = 2.0
         pose2.pose.position.z = 1
         pose2.header.frame_id = 'map'
         pose.pose.orientation.w = 1
-        zero_pose.set_translation_goal(root_link='odom_combined', tip_link='l_gripper_tool_frame', goal_pose=pose2)
+        zero_pose.set_translation_goal(goal_pose=pose2, tip_link='l_gripper_tool_frame', root_link='odom_combined')
         zero_pose.check_reachability(expected_error_codes=[MoveResult.UNREACHABLE])
 
     def test_unreachable_goal_5(self, zero_pose):
@@ -7499,7 +7499,7 @@ class TestReachability():
         pose.pose.position.z = 0.0
         pose.header.frame_id = 'map'
         pose.pose.orientation.w = 1
-        zero_pose.set_translation_goal(root_link='odom_combined', tip_link='base_footprint', goal_pose=pose)
+        zero_pose.set_translation_goal(goal_pose=pose, tip_link='base_footprint', root_link='odom_combined')
         js = {}
         js['odom_x_joint'] = 0.01
         zero_pose.set_joint_goal(js)

--- a/test/utils_for_tests.py
+++ b/test/utils_for_tests.py
@@ -376,7 +376,7 @@ class GiskardTestWrapper(GiskardWrapper):
         goal = PoseStamped()
         goal.header.frame_id = tip
         goal.pose.orientation.w = 1
-        self.set_rotation_goal(root, tip, goal)
+        self.set_rotation_goal(goal, tip, root)
 
     def set_rotation_goal(self, goal_pose, tip_link, root_link=None, weight=None, max_velocity=None):
         if not root_link:

--- a/test/utils_for_tests.py
+++ b/test/utils_for_tests.py
@@ -234,7 +234,6 @@ class GiskardTestWrapper(GiskardWrapper):
         self.tree = grow_tree()
         self.loop_once()
         # rospy.sleep(1)
-        #self.wrapper = GiskardWrapper(node_name=u'tests')
         super(GiskardTestWrapper, self).__init__(node_name=u'tests')
         self.results = Queue(100)
         self.default_root = self.get_robot().get_root()
@@ -334,12 +333,6 @@ class GiskardTestWrapper(GiskardWrapper):
                 np.testing.assert_almost_equal(current, goal, decimal,
                                                err_msg='{} at {} insteand of {}'.format(joint_name, current, goal))
 
-    # def set_joint_goal(self, js, weight=None):
-    #    """
-    #    :rtype js: dict
-    #    """
-    #    self.wrapper.set_joint_goal(js, weight=weight)
-
     def check_current_joint_state(self, expected, decimal=2):
         current_joint_state = to_joint_state_position_dict(self.get_current_joint_state())
         self.compare_joint_state(current_joint_state, expected, decimal=decimal)
@@ -384,9 +377,6 @@ class GiskardTestWrapper(GiskardWrapper):
         goal.header.frame_id = tip
         goal.pose.orientation.w = 1
         self.set_rotation_goal(root, tip, goal)
-
-    #def align_planes(self, tip_link, tip_normal, root_link=None, root_normal=None, weight=None):
-    #    self.wrapper.align_planes(tip_link, tip_normal, root_link, root_normal, weight)
 
     def set_rotation_goal(self, goal_pose, tip_link, root_link=None, weight=None, max_velocity=None):
         if not root_link:
@@ -451,7 +441,6 @@ class GiskardTestWrapper(GiskardWrapper):
         """
         if goal is None:
             goal = MoveActionGoal()
-            #goal.goal = self.wrapper._get_goal()
             goal.goal = self._get_goal()
             goal.goal.type = goal_type
         i = 0
@@ -472,7 +461,6 @@ class GiskardTestWrapper(GiskardWrapper):
     def send_goal_and_dont_wait(self, goal=None, goal_type=MoveGoal.PLAN_AND_EXECUTE, stop_after=20):
         if goal is None:
             goal = MoveActionGoal()
-            #goal.goal = self.wrapper._get_goal()
             goal.goal = self._get_goal()
             goal.goal.type = goal_type
         i = 0
@@ -507,12 +495,6 @@ class GiskardTestWrapper(GiskardWrapper):
                                                                                     expected_error_code),
                                                                                 error_message)
         return r.trajectory
-
-    #def add_waypoint(self):
-    #    self.wrapper.add_cmd()
-
-    #def set_json_goal(self, constraint_type, **kwargs):
-    #    self.wrapper.set_json_goal(constraint_type, **kwargs)
 
     def get_result_trajectory_position(self):
         trajectory = self.get_god_map().unsafe_get_data(identifier.trajectory)
@@ -636,40 +618,9 @@ class GiskardTestWrapper(GiskardWrapper):
         assert self.get_world().has_object(name)
         assert name in self.get_object_names().object_names
 
-    #def allow_all_collisions(self):
-    #    super(GiskardTestWrapper, self).allow_all_collisions()
-
     def avoid_all_collisions(self, distance=0.5):
         super(GiskardTestWrapper, self).avoid_all_collisions(distance)
         self.loop_once()
-
-    #def allow_self_collision(self):
-    #    self.wrapper.allow_self_collision()
-
-    #def avoid_self_collision(self):
-    #    self.wrapper.avoid_self_collision()
-
-
-
-    #def set_collision_entries(self, collisions_entries):
-    #    self.wrapper.set_collision_entries(collisions_entries)
-
-    #def allow_collision(self, robot_links, body_b, link_bs):
-    #    ces = []
-    #    ces.append(CollisionEntry(type=CollisionEntry.ALLOW_COLLISION,
-    #                              robot_links=robot_links,
-    #                              body_b=body_b,
-    #                              link_bs=link_bs))
-    #    self.set_collision_entries(ces)
-
-    #def avoid_collision(self, robot_links, body_b, link_bs, min_dist):
-    #    ces = []
-    #    ces.append(CollisionEntry(type=CollisionEntry.AVOID_COLLISION,
-    #                              robot_links=robot_links,
-    #                              body_b=body_b,
-    #                              link_bs=link_bs,
-    #                              min_dist=min_dist))
-    #    self.set_collision_entries(ces)
 
     def attach_box(self, name=u'box', size=None, frame_id=None, position=None, orientation=None, pose=None,
                    expected_response=UpdateWorldResponse.SUCCESS):

--- a/test/utils_for_tests.py
+++ b/test/utils_for_tests.py
@@ -219,7 +219,7 @@ def pykdl_frame_to_numpy(pykdl_frame):
                      [0, 0, 0, 1]])
 
 
-class GiskardTestWrapper(object):
+class GiskardTestWrapper(GiskardWrapper):
     def __init__(self, config_file):
         with open(get_ros_pkg_path(u'giskardpy') + u'/config/' + config_file) as f:
             config = yaml.load(f)
@@ -234,7 +234,8 @@ class GiskardTestWrapper(object):
         self.tree = grow_tree()
         self.loop_once()
         # rospy.sleep(1)
-        self.wrapper = GiskardWrapper(node_name=u'tests')
+        #self.wrapper = GiskardWrapper(node_name=u'tests')
+        super(GiskardTestWrapper, self).__init__(node_name=u'tests')
         self.results = Queue(100)
         self.default_root = self.get_robot().get_root()
         self.map = u'map'
@@ -249,6 +250,7 @@ class GiskardTestWrapper(object):
 
         self.joint_state_publisher = KeyDefaultDict(create_publisher)
         # rospy.sleep(1)
+
 
     def wait_for_synced(self):
         sleeper = rospy.Rate(self.tick_rate)
@@ -302,7 +304,7 @@ class GiskardTestWrapper(object):
         logging.loginfo(u'stopping plugins')
 
     def set_object_joint_state(self, object_name, joint_state):
-        self.wrapper.set_object_joint_state(object_name, joint_state)
+        super(GiskardTestWrapper, self).set_object_joint_state(object_name, joint_state)
         rospy.sleep(0.5)
         self.wait_for_synced()
         current_js = self.get_world().get_object(object_name).joint_state
@@ -332,13 +334,13 @@ class GiskardTestWrapper(object):
                 np.testing.assert_almost_equal(current, goal, decimal,
                                                err_msg='{} at {} insteand of {}'.format(joint_name, current, goal))
 
-    def set_joint_goal(self, js, weight=None):
-        """
-        :rtype js: dict
-        """
-        self.wrapper.set_joint_goal(js, weight=weight)
+    # def set_joint_goal(self, js, weight=None):
+    #    """
+    #    :rtype js: dict
+    #    """
+    #    self.wrapper.set_joint_goal(js, weight=weight)
 
-    def check_joint_state(self, expected, decimal=2):
+    def check_current_joint_state(self, expected, decimal=2):
         current_joint_state = to_joint_state_position_dict(self.get_current_joint_state())
         self.compare_joint_state(current_joint_state, expected, decimal=decimal)
 
@@ -349,7 +351,7 @@ class GiskardTestWrapper(object):
         self.set_joint_goal(goal, weight=weight)
         self.send_and_check_goal(expected_error_codes=expected_error_codes)
         if expected_error_codes == [MoveResult.SUCCESS]:
-            self.check_joint_state(goal, decimal=decimal)
+            self.check_current_joint_state(goal, decimal=decimal)
 
     #
     # CART GOAL STUFF ##################################################################################################
@@ -381,29 +383,29 @@ class GiskardTestWrapper(object):
         goal = PoseStamped()
         goal.header.frame_id = tip
         goal.pose.orientation.w = 1
-        self.set_rotation_goal(goal, tip, root)
+        self.set_rotation_goal(root, tip, goal)
 
-    def align_planes(self, tip_link, tip_normal, root_link=None, root_normal=None, weight=None):
-        self.wrapper.align_planes(tip_link, tip_normal, root_link, root_normal, weight)
+    #def align_planes(self, tip_link, tip_normal, root_link=None, root_normal=None, weight=None):
+    #    self.wrapper.align_planes(tip_link, tip_normal, root_link, root_normal, weight)
 
-    def set_rotation_goal(self, goal_pose, tip_link, root_link=None, max_velocity=None):
+    def set_rotation_goal(self, goal_pose, tip_link, root_link=None, weight=None, max_velocity=None):
         if not root_link:
             root_link = self.default_root
-        self.wrapper.set_rotation_goal(root_link, tip_link, goal_pose, max_velocity=max_velocity)
+        super(GiskardTestWrapper, self).set_rotation_goal(goal_pose, tip_link, root_link, max_velocity=max_velocity)
 
-    def set_translation_goal(self, goal_pose, tip_link, root_link=None, max_velocity=None):
+    def set_translation_goal(self, goal_pose, tip_link, root_link=None, weight=None, max_velocity=None):
         if not root_link:
             root_link = self.default_root
-        self.wrapper.set_translation_goal(root_link, tip_link, goal_pose, max_velocity=max_velocity)
+        super(GiskardTestWrapper, self).set_translation_goal(goal_pose, tip_link, root_link, max_velocity=max_velocity)
 
     def set_cart_goal(self, goal_pose, tip_link, root_link=None, weight=None, linear_velocity=None, angular_velocity=None):
         if not root_link:
             root_link = self.default_root
         if weight is not None:
-            self.wrapper.set_cart_goal(root_link, tip_link, goal_pose, weight=weight, max_linear_velocity=linear_velocity,
+            super(GiskardTestWrapper, self).set_cart_goal(goal_pose, tip_link, root_link, weight=weight, max_linear_velocity=linear_velocity,
                                        max_angular_velocity=angular_velocity)
         else:
-            self.wrapper.set_cart_goal(root_link, tip_link, goal_pose, max_linear_velocity=linear_velocity,
+            super(GiskardTestWrapper, self).set_cart_goal(goal_pose, tip_link, root_link, max_linear_velocity=linear_velocity,
                                        max_angular_velocity=angular_velocity)
 
     def set_and_check_cart_goal(self, goal_pose, tip_link, root_link=None, weight=None, linear_velocity=None, angular_velocity=None,
@@ -449,7 +451,8 @@ class GiskardTestWrapper(object):
         """
         if goal is None:
             goal = MoveActionGoal()
-            goal.goal = self.wrapper._get_goal()
+            #goal.goal = self.wrapper._get_goal()
+            goal.goal = self._get_goal()
             goal.goal.type = goal_type
         i = 0
         self.loop_once()
@@ -469,7 +472,8 @@ class GiskardTestWrapper(object):
     def send_goal_and_dont_wait(self, goal=None, goal_type=MoveGoal.PLAN_AND_EXECUTE, stop_after=20):
         if goal is None:
             goal = MoveActionGoal()
-            goal.goal = self.wrapper._get_goal()
+            #goal.goal = self.wrapper._get_goal()
+            goal.goal = self._get_goal()
             goal.goal.type = goal_type
         i = 0
         self.loop_once()
@@ -504,11 +508,11 @@ class GiskardTestWrapper(object):
                                                                                 error_message)
         return r.trajectory
 
-    def add_waypoint(self):
-        self.wrapper.add_cmd()
+    #def add_waypoint(self):
+    #    self.wrapper.add_cmd()
 
-    def add_json_goal(self, constraint_type, **kwargs):
-        self.wrapper.set_json_goal(constraint_type, **kwargs)
+    #def set_json_goal(self, constraint_type, **kwargs):
+    #    self.wrapper.set_json_goal(constraint_type, **kwargs)
 
     def get_result_trajectory_position(self):
         trajectory = self.get_god_map().unsafe_get_data(identifier.trajectory)
@@ -551,37 +555,37 @@ class GiskardTestWrapper(object):
         return self.get_god_map().get_data(world)
 
     def clear_world(self):
-        assert self.wrapper.clear_world().error_codes == UpdateWorldResponse.SUCCESS
+        assert super(GiskardTestWrapper, self).clear_world().error_codes == UpdateWorldResponse.SUCCESS
         assert len(self.get_world().get_object_names()) == 0
-        assert len(self.wrapper.get_object_names().object_names) == 0
+        assert len(self.get_object_names().object_names) == 0
         # assert len(self.get_robot().get_attached_objects()) == 0
         # assert self.get_world().has_object(u'plane')
 
     def remove_object(self, name, expected_response=UpdateWorldResponse.SUCCESS):
-        r = self.wrapper.remove_object(name)
+        r = super(GiskardTestWrapper, self).remove_object(name)
         assert r.error_codes == expected_response, \
             u'got: {}, expected: {}'.format(update_world_error_code(r.error_codes),
                                             update_world_error_code(expected_response))
         assert not self.get_world().has_object(name)
-        assert not name in self.wrapper.get_object_names().object_names
+        assert not name in self.get_object_names().object_names
 
     def detach_object(self, name, expected_response=UpdateWorldResponse.SUCCESS):
         if expected_response == UpdateWorldResponse.SUCCESS:
             p = self.get_robot().get_fk_pose(self.get_robot().get_root(), name)
             p = transform_pose(u'map', p)
-            assert name in self.wrapper.get_attached_objects().object_names, \
+            assert name in self.get_attached_objects().object_names, \
                 'there is no attached object named {}'.format(name)
-        r = self.wrapper.detach_object(name)
+        r = super(GiskardTestWrapper, self).detach_object(name)
         assert r.error_codes == expected_response, \
             u'got: {}, expected: {}'.format(update_world_error_code(r.error_codes),
                                             update_world_error_code(expected_response))
         if expected_response == UpdateWorldResponse.SUCCESS:
             assert self.get_world().has_object(name)
-            assert not name in self.wrapper.get_attached_objects().object_names, 'the object was not detached'
+            assert not name in self.get_attached_objects().object_names, 'the object was not detached'
             compare_poses(self.get_world().get_object(name).base_pose, p.pose, decimal=2)
 
     def add_box(self, name=u'box', size=(1, 1, 1), pose=None, expected_response=UpdateWorldResponse.SUCCESS):
-        r = self.wrapper.add_box(name, size, pose=pose)
+        r = super(GiskardTestWrapper, self).add_box(name, size, pose=pose)
         assert r.error_codes == expected_response, \
             u'got: {}, expected: {}'.format(update_world_error_code(r.error_codes),
                                             update_world_error_code(expected_response))
@@ -589,81 +593,83 @@ class GiskardTestWrapper(object):
         o_p = self.get_world().get_object(name).base_pose
         assert self.get_world().has_object(name)
         compare_poses(p.pose, o_p)
-        assert name in self.wrapper.get_object_names().object_names
-        compare_poses(o_p, self.wrapper.get_object_info(name).pose.pose)
+        assert name in self.get_object_names().object_names
+        compare_poses(o_p, self.get_object_info(name).pose.pose)
 
     def add_sphere(self, name=u'sphere', size=1, pose=None):
-        r = self.wrapper.add_sphere(name=name, size=size, pose=pose)
+        r = super(GiskardTestWrapper, self).add_sphere(name=name, size=size, pose=pose)
         assert r.error_codes == UpdateWorldResponse.SUCCESS, \
             u'got: {}, expected: {}'.format(update_world_error_code(r.error_codes),
                                             update_world_error_code(UpdateWorldResponse.SUCCESS))
         assert self.get_world().has_object(name)
-        assert name in self.wrapper.get_object_names().object_names
+        assert name in self.get_object_names().object_names
         o_p = self.get_world().get_object(name).base_pose
-        compare_poses(o_p, self.wrapper.get_object_info(name).pose.pose)
+        compare_poses(o_p, self.get_object_info(name).pose.pose)
 
     def add_cylinder(self, name=u'cylinder', size=[1, 1], pose=None):
-        r = self.wrapper.add_cylinder(name=name, height=size[0], radius=size[1], pose=pose)
+        r = super(GiskardTestWrapper, self).add_cylinder(name=name, height=size[0], radius=size[1], pose=pose)
         assert r.error_codes == UpdateWorldResponse.SUCCESS, \
             u'got: {}, expected: {}'.format(update_world_error_code(r.error_codes),
                                             update_world_error_code(UpdateWorldResponse.SUCCESS))
         assert self.get_world().has_object(name)
-        assert name in self.wrapper.get_object_names().object_names
+        assert name in self.get_object_names().object_names
 
     def add_mesh(self, name=u'cylinder', path=u'', pose=None, expected_error=UpdateWorldResponse.SUCCESS):
-        r = self.wrapper.add_mesh(name=name, mesh=path, pose=pose)
+        r = super(GiskardTestWrapper, self).add_mesh(name=name, mesh=path, pose=pose)
         assert r.error_codes == expected_error, \
             u'got: {}, expected: {}'.format(update_world_error_code(r.error_codes),
                                             update_world_error_code(expected_error))
         if expected_error == UpdateWorldResponse.SUCCESS:
             assert self.get_world().has_object(name)
-            assert name in self.wrapper.get_object_names().object_names
+            assert name in self.get_object_names().object_names
             o_p = self.get_world().get_object(name).base_pose
-            compare_poses(o_p, self.wrapper.get_object_info(name).pose.pose)
+            compare_poses(o_p, self.get_object_info(name).pose.pose)
         else:
             assert not self.get_world().has_object(name)
-            assert name not in self.wrapper.get_object_names().object_names
+            assert name not in self.get_object_names().object_names
 
     def add_urdf(self, name, urdf, pose, js_topic=u'', set_js_topic=None):
-        r = self.wrapper.add_urdf(name, urdf, pose, js_topic, set_js_topic=set_js_topic)
+        r = super(GiskardTestWrapper, self).add_urdf(name, urdf, pose, js_topic, set_js_topic=set_js_topic)
         assert r.error_codes == UpdateWorldResponse.SUCCESS, \
             u'got: {}, expected: {}'.format(update_world_error_code(r.error_codes),
                                             update_world_error_code(UpdateWorldResponse.SUCCESS))
         assert self.get_world().has_object(name)
-        assert name in self.wrapper.get_object_names().object_names
+        assert name in self.get_object_names().object_names
 
-    def allow_all_collisions(self):
-        self.wrapper.allow_all_collisions()
+    #def allow_all_collisions(self):
+    #    super(GiskardTestWrapper, self).allow_all_collisions()
 
     def avoid_all_collisions(self, distance=0.5):
-        self.wrapper.avoid_all_collisions(distance)
+        super(GiskardTestWrapper, self).avoid_all_collisions(distance)
         self.loop_once()
 
-    def allow_self_collision(self):
-        self.wrapper.allow_self_collision()
+    #def allow_self_collision(self):
+    #    self.wrapper.allow_self_collision()
 
-    def avoid_self_collision(self):
-        self.wrapper.avoid_self_collision()
+    #def avoid_self_collision(self):
+    #    self.wrapper.avoid_self_collision()
 
-    def add_collision_entries(self, collisions_entries):
-        self.wrapper.set_collision_entries(collisions_entries)
 
-    def allow_collision(self, robot_links, body_b, link_bs):
-        ces = []
-        ces.append(CollisionEntry(type=CollisionEntry.ALLOW_COLLISION,
-                                  robot_links=robot_links,
-                                  body_b=body_b,
-                                  link_bs=link_bs))
-        self.add_collision_entries(ces)
 
-    def avoid_collision(self, robot_links, body_b, link_bs, min_dist):
-        ces = []
-        ces.append(CollisionEntry(type=CollisionEntry.AVOID_COLLISION,
-                                  robot_links=robot_links,
-                                  body_b=body_b,
-                                  link_bs=link_bs,
-                                  min_dist=min_dist))
-        self.add_collision_entries(ces)
+    #def set_collision_entries(self, collisions_entries):
+    #    self.wrapper.set_collision_entries(collisions_entries)
+
+    #def allow_collision(self, robot_links, body_b, link_bs):
+    #    ces = []
+    #    ces.append(CollisionEntry(type=CollisionEntry.ALLOW_COLLISION,
+    #                              robot_links=robot_links,
+    #                              body_b=body_b,
+    #                              link_bs=link_bs))
+    #    self.set_collision_entries(ces)
+
+    #def avoid_collision(self, robot_links, body_b, link_bs, min_dist):
+    #    ces = []
+    #    ces.append(CollisionEntry(type=CollisionEntry.AVOID_COLLISION,
+    #                              robot_links=robot_links,
+    #                              body_b=body_b,
+    #                              link_bs=link_bs,
+    #                              min_dist=min_dist))
+    #    self.set_collision_entries(ces)
 
     def attach_box(self, name=u'box', size=None, frame_id=None, position=None, orientation=None, pose=None,
                    expected_response=UpdateWorldResponse.SUCCESS):
@@ -678,7 +684,7 @@ class GiskardTestWrapper(object):
                 expected_pose.pose.orientation = Quaternion(0, 0, 0, 1)
         else:
             expected_pose = deepcopy(pose)
-        r = self.wrapper.attach_box(name, size, frame_id, position, orientation, pose)
+        r = super(GiskardTestWrapper, self).attach_box(name, size, frame_id, position, orientation, pose)
         assert r.error_codes == expected_response, \
             u'got: {}, expected: {}'.format(update_world_error_code(r.error_codes),
                                             update_world_error_code(expected_response))
@@ -686,8 +692,8 @@ class GiskardTestWrapper(object):
             self.wait_for_synced()
             assert name in self.get_controllable_links()
             assert not self.get_world().has_object(name)
-            assert not name in self.wrapper.get_object_names().object_names
-            assert name in self.wrapper.get_attached_objects().object_names, 'object {} was not attached'
+            assert not name in self.get_object_names().object_names
+            assert name in self.get_attached_objects().object_names, 'object {} was not attached'
             assert scm.difference(self.get_robot().get_self_collision_matrix()) == set()
             assert len(scm) < len(self.get_robot().get_self_collision_matrix())
             compare_poses(expected_pose.pose, lookup_pose(frame_id, name).pose)
@@ -703,7 +709,7 @@ class GiskardTestWrapper(object):
             expected_pose.pose.orientation = Quaternion(*orientation)
         else:
             expected_pose.pose.orientation = Quaternion(0, 0, 0, 1)
-        r = self.wrapper.attach_cylinder(name, height, radius, frame_id, position, orientation)
+        r = super(GiskardTestWrapper, self).attach_cylinder(name, height, radius, frame_id, position, orientation)
         assert r.error_codes == expected_response, \
             u'got: {}, expected: {}'.format(update_world_error_code(r.error_codes),
                                             update_world_error_code(expected_response))
@@ -711,24 +717,24 @@ class GiskardTestWrapper(object):
             self.wait_for_synced()
             assert name in self.get_controllable_links()
             assert not self.get_world().has_object(name)
-            assert not name in self.wrapper.get_object_names().object_names
-            assert name in self.wrapper.get_attached_objects().object_names
+            assert not name in self.get_object_names().object_names
+            assert name in self.get_attached_objects().object_names
             assert scm.difference(self.get_robot().get_self_collision_matrix()) == set()
             assert len(scm) < len(self.get_robot().get_self_collision_matrix())
             compare_poses(expected_pose.pose, lookup_pose(frame_id, name).pose)
         self.loop_once()
 
-    def attach_existing(self, name=u'box', frame_id=None, expected_response=UpdateWorldResponse.SUCCESS):
+    def attach_object(self, name=u'box', frame_id=None, expected_response=UpdateWorldResponse.SUCCESS):
         scm = self.get_robot().get_self_collision_matrix()
-        r = self.wrapper.attach_object(name, frame_id)
+        r = super(GiskardTestWrapper, self).attach_object(name, frame_id)
         assert r.error_codes == expected_response, \
             u'got: {}, expected: {}'.format(update_world_error_code(r.error_codes),
                                             update_world_error_code(expected_response))
         self.wait_for_synced()
         assert name in self.get_controllable_links()
         assert not self.get_world().has_object(name)
-        assert not name in self.wrapper.get_object_names().object_names
-        assert name in self.wrapper.get_attached_objects().object_names
+        assert not name in self.get_object_names().object_names
+        assert name in self.get_attached_objects().object_names
         assert scm.difference(self.get_robot().get_self_collision_matrix()) == set()
         assert len(scm) < len(self.get_robot().get_self_collision_matrix())
         self.loop_once()


### PR DESCRIPTION
the following function signatures changed in the python interface:
set_cart_goal(): changed the order of the parameters to match the testwrapper interface
set_translation_goal(): changed the order of the parameters to match the testwrapper interface
set_translation_goal(): changed the order of the parameters to match the testwrapper interface

deleted the following redundant functions from the testwrapper:
-set_joint_goal(): inherited from python interface
-add_waypoint: replaced with add_cmd() from python interface
-allow_self_collision(): inherited from python interface
-avoid_self_collision(): inherited from python interface
-add_collision_entries(): replaced with set_collision_entries() from python interface
-allow_collision(): inherited from python interface
-avoid_collision(): inherited from python interface
-attach_existing(): replaced with attach_object() from python interface



