### PR TITLE
Trajectory splitter fix

### DIFF
--- a/scripts/joint_trajectory_splitter.py
+++ b/scripts/joint_trajectory_splitter.py
@@ -24,7 +24,6 @@ class done_cb(object):
         if result.error_code != control_msgs.msg.FollowJointTrajectoryResult.SUCCESSFUL:
             for client in self.action_clients:
                 client.cancel_goal()
-            self.success = False
             self._as.set_aborted(result)
             logging.logwarn(u'Joint Trajector Splitter: client \'{}\' failed to execute action goal \n {}'.format(self.name, result))
 
@@ -195,14 +194,15 @@ class JointTrajectorySplitter:
                 self.success = False
                 break
             else:
-                logging.loginfo('Client {} succeeded'.format(self.client_topics[i]))
+                if self._as.is_active():
+                    logging.loginfo('Client {} succeeded'.format(self.client_topics[i]))
 
-
-        if self.success:
-            self._as.set_succeeded()
-        else:
-            self.cancel_all_goals()
-            self._as.set_aborted()
+        if self._as.is_active():
+            if self.success:
+                self._as.set_succeeded()
+            else:
+                self.cancel_all_goals()
+                self._as.set_aborted()
 
     def cancel_all_goals(self):
         logging.logwarn('Canceling all goals of connected controllers')

--- a/scripts/joint_trajectory_splitter.py
+++ b/scripts/joint_trajectory_splitter.py
@@ -191,15 +191,23 @@ class JointTrajectorySplitter:
             now = rospy.Time.now()
             timeout = timeout - (now - start)
             if not finished_before_timeout:
-                logging.logwarn("Client took to long to finish action")
+                logging.logwarn("Client took to long to finish action; stopping {}".format(self.client_topics[i]))
                 self.success = False
-                self._as.set_aborted()
                 break
+            else:
+                logging.loginfo('Client {} succeeded'.format(self.client_topics[i]))
 
 
         if self.success:
             self._as.set_succeeded()
+        else:
+            self.cancel_all_goals()
+            self._as.set_aborted()
 
+    def cancel_all_goals(self):
+        logging.logwarn('Canceling all goals of connected controllers')
+        for client in self.action_clients:
+            client.cancel_all_goals()
 
     def feedback_cb(self, feedback):
         self._as.publish_feedback(feedback)

--- a/test/joint_trajectory_splitter/failing_action_server.py
+++ b/test/joint_trajectory_splitter/failing_action_server.py
@@ -13,12 +13,18 @@ class FailingActionServer(object):
         self._as = actionlib.SimpleActionServer(self._action_name, control_msgs.msg.FollowJointTrajectoryAction,
                                                 execute_cb=self.execute_cb, auto_start=False)
         self._as.start()
+        self._as.register_preempt_callback(self.preempt_requested)
+
+    def preempt_requested(self):
+        print('cancel called')
+        self._as.set_preempted()
 
     def execute_cb(self, goal):
-        rospy.sleep(rospy.Duration(10))
+        rospy.sleep(goal.trajectory.points[1].time_from_start)
         result = control_msgs.msg.FollowJointTrajectoryResult()
         result.error_code = control_msgs.msg.FollowJointTrajectoryResult.GOAL_TOLERANCE_VIOLATED
-        self._as.set_succeeded(result)
+        if self._as.is_active():
+            self._as.set_aborted(result)
 
 
 if __name__ == '__main__':

--- a/test/joint_trajectory_splitter/invalid_joints_action_server.py
+++ b/test/joint_trajectory_splitter/invalid_joints_action_server.py
@@ -13,12 +13,18 @@ class InvalidJointsActionServer(object):
         self._as = actionlib.SimpleActionServer(self._action_name, control_msgs.msg.FollowJointTrajectoryAction,
                                                 execute_cb=self.execute_cb, auto_start=False)
         self._as.start()
+        self._as.register_preempt_callback(self.preempt_requested)
+
+    def preempt_requested(self):
+        print('cancel called')
+        self._as.set_preempted()
 
     def execute_cb(self, goal):
         rospy.sleep(goal.trajectory.points[-1].time_from_start)
         result = control_msgs.msg.FollowJointTrajectoryResult()
         result.error_code = control_msgs.msg.FollowJointTrajectoryResult.INVALID_JOINTS
-        self._as.set_succeeded(result)
+        if self._as.is_active():
+            self._as.set_aborted(result)
 
 
 if __name__ == '__main__':

--- a/test/joint_trajectory_splitter/successful_action_server.py
+++ b/test/joint_trajectory_splitter/successful_action_server.py
@@ -22,7 +22,8 @@ class SuccessfulActionServer(object):
 
     def execute_cb(self, goal):
         rospy.sleep(goal.trajectory.points[-1].time_from_start)
-        self._as.set_succeeded()
+        if self._as.is_active():
+            self._as.set_succeeded()
 
 
 if __name__ == '__main__':

--- a/test/joint_trajectory_splitter/successful_action_server.py
+++ b/test/joint_trajectory_splitter/successful_action_server.py
@@ -14,6 +14,11 @@ class SuccessfulActionServer(object):
         self._as = actionlib.SimpleActionServer(self._action_name, control_msgs.msg.FollowJointTrajectoryAction,
                                                 execute_cb=self.execute_cb, auto_start=False)
         self._as.start()
+        self._as.register_preempt_callback(self.preempt_requested)
+
+    def preempt_requested(self):
+        print('cancel called')
+        self._as.set_preempted()
 
     def execute_cb(self, goal):
         rospy.sleep(goal.trajectory.points[-1].time_from_start)

--- a/test/joint_trajectory_splitter/timeout_action_server.py
+++ b/test/joint_trajectory_splitter/timeout_action_server.py
@@ -22,7 +22,8 @@ class TimeoutActionServer(object):
 
     def execute_cb(self, goal):
         rospy.sleep(goal.trajectory.points[2].time_from_start + rospy.Duration(5))
-        self._as.set_succeeded()
+        if self._as.is_active():
+            self._as.set_succeeded()
 
 
 if __name__ == '__main__':

--- a/test/joint_trajectory_splitter/timeout_action_server.py
+++ b/test/joint_trajectory_splitter/timeout_action_server.py
@@ -14,6 +14,11 @@ class TimeoutActionServer(object):
         self._as = actionlib.SimpleActionServer(self._action_name, control_msgs.msg.FollowJointTrajectoryAction,
                                                 execute_cb=self.execute_cb, auto_start=False)
         self._as.start()
+        self._as.register_preempt_callback(self.preempt_requested)
+
+    def preempt_requested(self):
+        print('cancel called')
+        self._as.set_preempted()
 
     def execute_cb(self, goal):
         rospy.sleep(goal.trajectory.points[2].time_from_start + rospy.Duration(5))

--- a/test/test_joint_trajectory_splitter.py
+++ b/test/test_joint_trajectory_splitter.py
@@ -342,6 +342,8 @@ def test_invalid_joints_error(launch_invalid_joints_test_nodes):
     status = action_client.get_state()
     assert status == actionlib.GoalStatus.ABORTED
     assert result.error_code == control_msgs.msg.FollowJointTrajectoryResult.INVALID_JOINTS
+    assert launch_invalid_joints_test_nodes.get_other_state(0) == actionlib.GoalStatus.PREEMPTED
+    assert launch_invalid_joints_test_nodes.get_other_state(1) == actionlib.GoalStatus.ABORTED
 
 
 def test_missing_joint_in_goal(launch_successful_test_nodes):
@@ -355,6 +357,16 @@ def test_missing_joint_in_goal(launch_successful_test_nodes):
     status = action_client.get_state()
     assert status == actionlib.GoalStatus.ABORTED
     assert result.error_code == control_msgs.msg.FollowJointTrajectoryResult.INVALID_GOAL
+    try:
+        launch_successful_test_nodes.get_other_state(0)
+        assert False
+    except:
+        pass
+    try:
+        launch_successful_test_nodes.get_other_state(1)
+        assert False
+    except:
+        pass
 
 
 def test_successful_goal(launch_successful_test_nodes):
@@ -368,6 +380,8 @@ def test_successful_goal(launch_successful_test_nodes):
     status = action_client.get_state()
     assert status == actionlib.GoalStatus.SUCCEEDED
     assert result.error_code == control_msgs.msg.FollowJointTrajectoryResult.SUCCESSFUL
+    assert launch_successful_test_nodes.get_other_state(0) == actionlib.GoalStatus.SUCCEEDED
+    assert launch_successful_test_nodes.get_other_state(1) == actionlib.GoalStatus.SUCCEEDED
 
 
 def test_cancel_goal(launch_successful_test_nodes):
@@ -378,6 +392,7 @@ def test_cancel_goal(launch_successful_test_nodes):
     action_client.send_goal(simple_trajectory_goal)
     rospy.sleep(0.2)
     action_client.cancel_goal()
+    rospy.sleep(0.2)
     action_client.wait_for_result()
     result = action_client.get_result()
     status = action_client.get_state()

--- a/test/test_joint_trajectory_splitter.py
+++ b/test/test_joint_trajectory_splitter.py
@@ -1,13 +1,43 @@
 #! /usr/bin/env python
 
-import rospy
+import copy
+
 import actionlib
 import control_msgs.msg
-import roslaunch
-import trajectory_msgs.msg
 import pytest
-import copy
+import roslaunch
+import rospy
+import trajectory_msgs.msg
+from actionlib_msgs.msg import GoalStatusArray
+
 from giskardpy import logging
+
+
+class Clients(object):
+    class cb(object):
+        def __init__(self, clients, statuses, i):
+            self.clients = clients
+            self.statuses = statuses
+            self.i = i
+
+        def __call__(self, data):
+            if data.status_list != []:
+                self.statuses[self.i] = data
+
+    def __init__(self, splitter, others, state_topics):
+        self.splitter = splitter
+        self.others = others
+        self.state_topics = []
+        self.statuses = [None for _ in state_topics]
+        for i, state_topic in enumerate(state_topics):
+            self.state_topics.append(rospy.Subscriber(state_topic,
+                                                      GoalStatusArray,
+                                                      self.cb(self.others, self.statuses, i),
+                                                      queue_size=10))
+
+    def get_other_state(self, i):
+        return self.statuses[i].status_list[0].status
+
 
 @pytest.fixture(scope=u'module')
 def init_ros():
@@ -56,7 +86,7 @@ def get_missing_joint_goal():
 
 def get_long_trajectory_goal():
     goal = control_msgs.msg.FollowJointTrajectoryGoal()
-    goal.trajectory.joint_names = ['joint1','joint2', 'joint3', 'joint4']
+    goal.trajectory.joint_names = ['joint1', 'joint2', 'joint3', 'joint4']
 
     point1 = trajectory_msgs.msg.JointTrajectoryPoint()
     point1.positions.extend([1.0, 1.0, 1, 0])
@@ -73,17 +103,18 @@ def get_long_trajectory_goal():
 
     return goal
 
+
 @pytest.fixture(scope=u'module')
 def ros_launch():
     launch = roslaunch.scriptapi.ROSLaunch()
     launch.start()
     return launch
 
+
 @pytest.fixture(scope=u'function')
 def launch_state_publisher1(request, init_ros, ros_launch):
-
     rospy.set_param('/state_publisher1/joint_names', ['joint1', 'joint2'])
-    node = roslaunch.core.Node('giskardpy', 'state_publisher.py', name='state_publisher1')
+    node = roslaunch.core.Node('giskardpy', 'state_publisher.py', name='state_publisher1', output='screen')
     state_publisher1 = ros_launch.launch(node)
 
     def fin():
@@ -99,7 +130,7 @@ def launch_state_publisher1(request, init_ros, ros_launch):
 @pytest.fixture(scope=u'function')
 def launch_state_publisher2(request, init_ros, ros_launch):
     rospy.set_param('/state_publisher2/joint_names', ['joint3', 'joint4'])
-    node = roslaunch.core.Node('giskardpy', 'state_publisher.py', name='state_publisher2')
+    node = roslaunch.core.Node('giskardpy', 'state_publisher.py', name='state_publisher2', output='screen')
     state_publisher2 = ros_launch.launch(node)
 
     def fin():
@@ -114,15 +145,18 @@ def launch_state_publisher2(request, init_ros, ros_launch):
 
 @pytest.fixture(scope=u'function')
 def launch_timeout_test_nodes(request, init_ros, ros_launch, launch_state_publisher1, launch_state_publisher2):
-    node = roslaunch.core.Node('giskardpy', 'successful_action_server.py', name='successful_action_server1')
+    node = roslaunch.core.Node('giskardpy', 'successful_action_server.py', name='successful_action_server1',
+                               output='screen')
     process1 = ros_launch.launch(node)
 
-    node = roslaunch.core.Node('giskardpy', 'timeout_action_server.py', name='timeout_action_server1')
+    node = roslaunch.core.Node('giskardpy', 'timeout_action_server.py', name='timeout_action_server1', output='screen')
     process2 = ros_launch.launch(node)
 
     rospy.set_param('/joint_trajectory_splitter/state_topics', ['/state_publisher1', '/state_publisher2'])
-    rospy.set_param('/joint_trajectory_splitter/client_topics', ['/successful_action_server1', '/timeout_action_server1'])
-    node = roslaunch.core.Node('giskardpy', 'joint_trajectory_splitter.py', name='joint_trajectory_splitter')
+    rospy.set_param('/joint_trajectory_splitter/client_topics',
+                    ['/successful_action_server1', '/timeout_action_server1'])
+    node = roslaunch.core.Node('giskardpy', 'joint_trajectory_splitter.py', name='joint_trajectory_splitter',
+                               output='screen')
     process3 = ros_launch.launch(node)
 
     def fin():
@@ -131,24 +165,40 @@ def launch_timeout_test_nodes(request, init_ros, ros_launch, launch_state_publis
         process3.stop()
         rospy.delete_param('/joint_trajectory_splitter/state_topics')
         rospy.delete_param('/joint_trajectory_splitter/client_topics')
-        while(process1.is_alive()  or process2.is_alive() or process3.is_alive()):
+        while (process1.is_alive() or process2.is_alive() or process3.is_alive()):
             logging.loginfo('waiting for nodes to finish')
             rospy.sleep(0.2)
 
     request.addfinalizer(fin)
+    splitter = actionlib.SimpleActionClient('/whole_body_controller/follow_joint_trajectory/',
+                                            control_msgs.msg.FollowJointTrajectoryAction)
+    others = [
+        actionlib.SimpleActionClient('/successful_action_server1/',
+                                     control_msgs.msg.FollowJointTrajectoryAction),
+        actionlib.SimpleActionClient('/successful_action_server1/',
+                                     control_msgs.msg.FollowJointTrajectoryAction)
+    ]
+    r = Clients(splitter, others, ['/successful_action_server1/status',
+                                   '/timeout_action_server1/status'])
+    rospy.sleep(2)
+    return r
 
 
 @pytest.fixture(scope=u'function')
 def launch_successful_test_nodes(request, init_ros, ros_launch, launch_state_publisher1, launch_state_publisher2):
-    node = roslaunch.core.Node('giskardpy', 'successful_action_server.py', name='successful_action_server1')
+    node = roslaunch.core.Node('giskardpy', 'successful_action_server.py', name='successful_action_server1',
+                               output='screen')
     process1 = ros_launch.launch(node)
 
-    node = roslaunch.core.Node('giskardpy', 'successful_action_server.py', name='successful_action_server2')
+    node = roslaunch.core.Node('giskardpy', 'successful_action_server.py', name='successful_action_server2',
+                               output='screen')
     process2 = ros_launch.launch(node)
 
     rospy.set_param('/joint_trajectory_splitter/state_topics', ['/state_publisher1', '/state_publisher2'])
-    rospy.set_param('/joint_trajectory_splitter/client_topics', ['/successful_action_server1', '/successful_action_server2'])
-    node = roslaunch.core.Node('giskardpy', 'joint_trajectory_splitter.py', name='joint_trajectory_splitter')
+    rospy.set_param('/joint_trajectory_splitter/client_topics',
+                    ['/successful_action_server1', '/successful_action_server2'])
+    node = roslaunch.core.Node('giskardpy', 'joint_trajectory_splitter.py', name='joint_trajectory_splitter',
+                               output='screen')
     process3 = ros_launch.launch(node)
 
     def fin():
@@ -157,27 +207,44 @@ def launch_successful_test_nodes(request, init_ros, ros_launch, launch_state_pub
         process3.stop()
         rospy.delete_param('/joint_trajectory_splitter/state_topics')
         rospy.delete_param('/joint_trajectory_splitter/client_topics')
-        while(process1.is_alive() or process2.is_alive() or process3.is_alive()):
+        while (process1.is_alive() or process2.is_alive() or process3.is_alive()):
             logging.loginfo('waiting for nodes to finish')
             rospy.sleep(0.2)
 
     request.addfinalizer(fin)
+
+    splitter = actionlib.SimpleActionClient('/whole_body_controller/follow_joint_trajectory/',
+                                            control_msgs.msg.FollowJointTrajectoryAction)
+    others = [
+        actionlib.SimpleActionClient('/successful_action_server1/',
+                                     control_msgs.msg.FollowJointTrajectoryAction),
+        actionlib.SimpleActionClient('/successful_action_server2/',
+                                     control_msgs.msg.FollowJointTrajectoryAction)
+    ]
+    r = Clients(splitter, others, ['/successful_action_server1/status',
+                                   '/successful_action_server2/status'])
+    rospy.sleep(2)
+    return r
+
 
 @pytest.fixture(scope=u'function')
 def launch_invalid_joints_test_nodes(request, init_ros, ros_launch, launch_state_publisher1, launch_state_publisher2):
     launch = roslaunch.scriptapi.ROSLaunch()
     launch.start()
 
-    node = roslaunch.core.Node('giskardpy', 'successful_action_server.py', name='successful_action_server1')
+    node = roslaunch.core.Node('giskardpy', 'successful_action_server.py', name='successful_action_server1',
+                               output='screen')
     process1 = launch.launch(node)
 
-    node = roslaunch.core.Node('giskardpy', 'invalid_joints_action_server.py', name='invalid_joints_action_server1')
+    node = roslaunch.core.Node('giskardpy', 'invalid_joints_action_server.py', name='invalid_joints_action_server1',
+                               output='screen')
     process2 = launch.launch(node)
 
-
     rospy.set_param('/joint_trajectory_splitter/state_topics', ['/state_publisher1', '/state_publisher2'])
-    rospy.set_param('/joint_trajectory_splitter/client_topics', ['/successful_action_server1', '/invalid_joints_action_server1'])
-    node = roslaunch.core.Node('giskardpy', 'joint_trajectory_splitter.py', name='joint_trajectory_splitter')
+    rospy.set_param('/joint_trajectory_splitter/client_topics',
+                    ['/successful_action_server1', '/invalid_joints_action_server1'])
+    node = roslaunch.core.Node('giskardpy', 'joint_trajectory_splitter.py', name='joint_trajectory_splitter',
+                               output='screen')
     process3 = launch.launch(node)
 
     def fin():
@@ -186,11 +253,25 @@ def launch_invalid_joints_test_nodes(request, init_ros, ros_launch, launch_state
         process3.stop()
         rospy.delete_param('/joint_trajectory_splitter/state_topics')
         rospy.delete_param('/joint_trajectory_splitter/client_topics')
-        while(process1.is_alive() or process2.is_alive() or process3.is_alive()):
+        while (process1.is_alive() or process2.is_alive() or process3.is_alive()):
             logging.loginfo('waiting for nodes to finish')
             rospy.sleep(0.2)
 
     request.addfinalizer(fin)
+
+    splitter = actionlib.SimpleActionClient('/whole_body_controller/follow_joint_trajectory/',
+                                            control_msgs.msg.FollowJointTrajectoryAction)
+    others = [
+        actionlib.SimpleActionClient('/successful_action_server1/',
+                                     control_msgs.msg.FollowJointTrajectoryAction),
+        actionlib.SimpleActionClient('/invalid_joints_action_server1/',
+                                     control_msgs.msg.FollowJointTrajectoryAction)
+    ]
+    r = Clients(splitter, others, ['/successful_action_server1/status',
+                                   '/invalid_joints_action_server1/status'])
+    rospy.sleep(2)
+    return r
+
 
 @pytest.fixture(scope=u'function')
 def launch_failing_goal_test_nodes(request, init_ros, ros_launch, launch_state_publisher1, launch_state_publisher2):
@@ -204,7 +285,8 @@ def launch_failing_goal_test_nodes(request, init_ros, ros_launch, launch_state_p
     process2 = launch.launch(node)
 
     rospy.set_param('/joint_trajectory_splitter/state_topics', ['/state_publisher1', '/state_publisher1'])
-    rospy.set_param('/joint_trajectory_splitter/client_topics', ['/successful_action_server1', '/failing_action_server1'])
+    rospy.set_param('/joint_trajectory_splitter/client_topics',
+                    ['/successful_action_server1', '/failing_action_server1'])
     node = roslaunch.core.Node('giskardpy', 'joint_trajectory_splitter.py', name='joint_trajectory_splitter')
     process3 = launch.launch(node)
 
@@ -214,24 +296,36 @@ def launch_failing_goal_test_nodes(request, init_ros, ros_launch, launch_state_p
         process3.stop()
         rospy.delete_param('/joint_trajectory_splitter/state_topics')
         rospy.delete_param('/joint_trajectory_splitter/client_topics')
-        while(process1.is_alive() or process2.is_alive() or process3.is_alive()):
+        while (process1.is_alive() or process2.is_alive() or process3.is_alive()):
             logging.loginfo('waiting for nodes to finish')
             rospy.sleep(0.2)
 
     request.addfinalizer(fin)
 
-
+    splitter = actionlib.SimpleActionClient('/whole_body_controller/follow_joint_trajectory/',
+                                            control_msgs.msg.FollowJointTrajectoryAction)
+    others = [
+        actionlib.SimpleActionClient('/successful_action_server1/',
+                                     control_msgs.msg.FollowJointTrajectoryAction),
+        actionlib.SimpleActionClient('/failing_action_server1/',
+                                     control_msgs.msg.FollowJointTrajectoryAction)
+    ]
+    r = Clients(splitter, others, ['/successful_action_server1/status',
+                                   '/failing_action_server1/status'])
+    rospy.sleep(2)
+    return r
 
 
 def test_timeout(launch_timeout_test_nodes):
-    action_client = actionlib.SimpleActionClient('/whole_body_controller/follow_joint_trajectory/',
-                                          control_msgs.msg.FollowJointTrajectoryAction)
+    splitter = launch_timeout_test_nodes.splitter
     simple_trajectory_goal = get_simple_trajectory_goal()
-    action_client.wait_for_server()
-    action_client.send_goal(simple_trajectory_goal)
-    action_client.wait_for_result()
-    status = action_client.get_state()
+    splitter.wait_for_server()
+    splitter.send_goal(simple_trajectory_goal)
+    splitter.wait_for_result()
+    status = splitter.get_state()
     assert status == actionlib.GoalStatus.ABORTED
+    assert launch_timeout_test_nodes.get_other_state(0) == actionlib.GoalStatus.SUCCEEDED
+    assert launch_timeout_test_nodes.get_other_state(1) == actionlib.GoalStatus.PREEMPTED
 
 
 def test_invalid_joints_error(launch_invalid_joints_test_nodes):
@@ -245,6 +339,7 @@ def test_invalid_joints_error(launch_invalid_joints_test_nodes):
     status = action_client.get_state()
     assert status == actionlib.GoalStatus.ABORTED
     assert result.error_code == control_msgs.msg.FollowJointTrajectoryResult.INVALID_JOINTS
+
 
 def test_missing_joint_in_goal(launch_successful_test_nodes):
     action_client = actionlib.SimpleActionClient('/whole_body_controller/follow_joint_trajectory/',
@@ -271,6 +366,24 @@ def test_successful_goal(launch_successful_test_nodes):
     assert status == actionlib.GoalStatus.SUCCEEDED
     assert result.error_code == control_msgs.msg.FollowJointTrajectoryResult.SUCCESSFUL
 
+
+def test_cancel_goal(launch_successful_test_nodes):
+    action_client = actionlib.SimpleActionClient('/whole_body_controller/follow_joint_trajectory/',
+                                                 control_msgs.msg.FollowJointTrajectoryAction)
+    simple_trajectory_goal = get_simple_trajectory_goal()
+    action_client.wait_for_server()
+    action_client.send_goal(simple_trajectory_goal)
+    rospy.sleep(0.2)
+    action_client.cancel_goal()
+    action_client.wait_for_result()
+    result = action_client.get_result()
+    status = action_client.get_state()
+    assert status == actionlib.GoalStatus.PREEMPTED
+    assert result.error_code == control_msgs.msg.FollowJointTrajectoryResult.SUCCESSFUL
+    assert launch_successful_test_nodes.get_other_state(0) == actionlib.GoalStatus.PREEMPTED
+    assert launch_successful_test_nodes.get_other_state(1) == actionlib.GoalStatus.PREEMPTED
+
+
 def test_failing_goal(launch_failing_goal_test_nodes):
     action_client = actionlib.SimpleActionClient('/whole_body_controller/follow_joint_trajectory/',
                                                  control_msgs.msg.FollowJointTrajectoryAction)
@@ -284,4 +397,4 @@ def test_failing_goal(launch_failing_goal_test_nodes):
     status = action_client.get_state()
     assert status == actionlib.GoalStatus.ABORTED
     assert result.error_code == control_msgs.msg.FollowJointTrajectoryResult.GOAL_TOLERANCE_VIOLATED
-    assert end-start < rospy.Duration(20) and end-start >= rospy.Duration(10)
+    assert end - start < rospy.Duration(20) and end - start >= rospy.Duration(10)

--- a/test/test_joint_trajectory_splitter.py
+++ b/test/test_joint_trajectory_splitter.py
@@ -278,16 +278,19 @@ def launch_failing_goal_test_nodes(request, init_ros, ros_launch, launch_state_p
     launch = roslaunch.scriptapi.ROSLaunch()
     launch.start()
 
-    node = roslaunch.core.Node('giskardpy', 'successful_action_server.py', name='successful_action_server1')
+    node = roslaunch.core.Node('giskardpy', 'successful_action_server.py', name='successful_action_server1',
+                               output='screen')
     process1 = launch.launch(node)
 
-    node = roslaunch.core.Node('giskardpy', 'failing_action_server.py', name='failing_action_server1')
+    node = roslaunch.core.Node('giskardpy', 'failing_action_server.py', name='failing_action_server1',
+                               output='screen')
     process2 = launch.launch(node)
 
     rospy.set_param('/joint_trajectory_splitter/state_topics', ['/state_publisher1', '/state_publisher1'])
     rospy.set_param('/joint_trajectory_splitter/client_topics',
                     ['/successful_action_server1', '/failing_action_server1'])
-    node = roslaunch.core.Node('giskardpy', 'joint_trajectory_splitter.py', name='joint_trajectory_splitter')
+    node = roslaunch.core.Node('giskardpy', 'joint_trajectory_splitter.py', name='joint_trajectory_splitter',
+                               output='screen')
     process3 = launch.launch(node)
 
     def fin():
@@ -398,3 +401,5 @@ def test_failing_goal(launch_failing_goal_test_nodes):
     assert status == actionlib.GoalStatus.ABORTED
     assert result.error_code == control_msgs.msg.FollowJointTrajectoryResult.GOAL_TOLERANCE_VIOLATED
     assert end - start < rospy.Duration(20) and end - start >= rospy.Duration(10)
+    assert launch_failing_goal_test_nodes.get_other_state(0) == actionlib.GoalStatus.PREEMPTED
+    assert launch_failing_goal_test_nodes.get_other_state(1) == actionlib.GoalStatus.ABORTED


### PR DESCRIPTION
properly kills other connected action servers, if one aborts.