### PR TITLE
Noetic compatibility

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="3">
   <name>giskardpy</name>
   <version>0.0.0</version>
   <description>The giskardpy package</description>
@@ -35,22 +35,24 @@
   <!--   <build_depend>message_generation</build_depend> -->
   <!-- Use buildtool_depend for build tool packages: -->
   <!--   <buildtool_depend>catkin</buildtool_depend> -->
-  <!-- Use run_depend for packages you need at runtime: -->
-  <!--   <run_depend>message_runtime</run_depend> -->
+  <!-- Use exec_depend for packages you need at runtime: -->
+  <!--   <exec_depend>message_runtime</exec_depend> -->
   <!-- Use test_depend for packages you need only for testing: -->
   <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
 
-  <run_depend>python-numpy</run_depend>
-  <run_depend>cython</run_depend>
-  <run_depend>urdfdom_py</run_depend>
-  <run_depend>qpoases</run_depend>
-  <run_depend>giskard_msgs</run_depend>
-  <run_depend>py_trees</run_depend>
-  <run_depend>py_trees_ros</run_depend>
-  <run_depend>joint_trajectory_action</run_depend>
-  <run_depend>rospy_message_converter</run_depend>
-  <run_depend>python-pytest</run_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-numpy</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-numpy</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">cython</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">cython3</exec_depend>
+  <exec_depend>urdfdom_py</exec_depend>
+  <exec_depend>qpoases</exec_depend>
+  <exec_depend>giskard_msgs</exec_depend>
+  <exec_depend>py_trees</exec_depend>
+  <exec_depend>py_trees_ros</exec_depend>
+  <exec_depend>rospy_message_converter</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-pytest</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-pytest</exec_depend>
   <test_depend>rosunit</test_depend>
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/package.xml
+++ b/package.xml
@@ -48,11 +48,16 @@
   <exec_depend>urdfdom_py</exec_depend>
   <exec_depend>qpoases</exec_depend>
   <exec_depend>giskard_msgs</exec_depend>
+  <exec_depend>control_msgs</exec_depend>
   <exec_depend>py_trees</exec_depend>
   <exec_depend>py_trees_ros</exec_depend>
   <exec_depend>rospy_message_converter</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-pytest</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-pytest</exec_depend>
+  <exec_depend>omni_pose_follower</exec_depend>
+  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>topic_tools</exec_depend>
+  <exec_depend>xacro</exec_depend>
   <test_depend>rosunit</test_depend>
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/scripts/joint_trajectory_splitter.py
+++ b/scripts/joint_trajectory_splitter.py
@@ -2,8 +2,11 @@
 
 import rospy
 import control_msgs.msg
-import pr2_controllers_msgs.msg
 import trajectory_msgs.msg
+try:
+    import pr2_controllers_msgs.msg
+except ImportError:
+    pass
 import actionlib
 from rospy import AnyMsg
 

--- a/scripts/move_base_simple_goal.py
+++ b/scripts/move_base_simple_goal.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import rospy
 from geometry_msgs.msg import PoseStamped
 from tf.transformations import rotation_from_matrix, quaternion_matrix


### PR DESCRIPTION
This fixes some minor issues:

* The package `pr2_controllers_msgs` isn't available for ROS Noetic. As the code already handles the newer `control_msgs` package, it suffices to ignore import failures.
* Noetic requires some python3 packages
* Added some missing package dependencies in package.xml