### PR TITLE
Shaking Constraint

### DIFF
--- a/config/boxy.yaml
+++ b/config/boxy.yaml
@@ -48,7 +48,7 @@ plugins:
     normalize_position: False # centers the joint positions around 0 on the y axis
     tick_stride: 0.5 # the distance between ticks in the plot. if tick_stride <= 0 pyplot determines the ticks automatically
   WiggleCancel: # cancels planning if high frequencies are detected in the trajectory
-    amplitude_threshold: 0.15 # the amplitude of a frequency must exceed this threshold to be detected as wiggling
+    amplitude_threshold: 0.55 # the amplitude of a frequency must exceed this threshold to be detected as wiggling
     window_size: 21 # size of the moving window of sample points
     frequency_range: 0.4 # must be in the range [0,1]. Only frequencies in the range [max_detectable_frequency * wiggle_frequency_range, max_detectable_frequency] are considered as wiggling. So a value of 0 means that every frequency with an amplitude above wiggle_detection_threshold is detected as wiggling and a value of 1 means that only the max_detectable_frequency can trigger a wiggle detection.      max_detectable_frequency = 1 / (2 * sample_period)
   tf_publisher:

--- a/config/boxy_sim.yaml
+++ b/config/boxy_sim.yaml
@@ -48,7 +48,7 @@ plugins:
     normalize_position: False # centers the joint positions around 0 on the y axis
     tick_stride: 0.5 # the distance between ticks in the plot. if tick_stride <= 0 pyplot determines the ticks automatically
   WiggleCancel: # cancels planning if high frequencies are detected in the trajectory
-    amplitude_threshold: 0.15 # the amplitude of a frequency must exceed this threshold to be detected as wiggling
+    amplitude_threshold: 0.55 # the amplitude of a frequency must exceed this threshold to be detected as wiggling
     window_size: 21 # size of the moving window of sample points
     frequency_range: 0.4 # must be in the range [0,1]. Only frequencies in the range [max_detectable_frequency * wiggle_frequency_range, max_detectable_frequency] are considered as wiggling. So a value of 0 means that every frequency with an amplitude above wiggle_detection_threshold is detected as wiggling and a value of 1 means that only the max_detectable_frequency can trigger a wiggle detection.      max_detectable_frequency = 1 / (2 * sample_period)
   tf_publisher:

--- a/config/donbot.yaml
+++ b/config/donbot.yaml
@@ -45,7 +45,7 @@ plugins:
     normalize_position: False # centers the joint positions around 0 on the y axis
     tick_stride: 0.5 # the distance between ticks in the plot. if tick_stride <= 0 pyplot determines the ticks automatically
   WiggleCancel: # cancels planning if high frequencies are detected in the trajectory
-    amplitude_threshold: 0.15 # the amplitude of a frequency must exceed this threshold to be detected as wiggling
+    amplitude_threshold: 0.55 # the amplitude of a frequency must exceed this threshold to be detected as wiggling
     window_size: 21 # size of the moving window of sample points
     frequency_range: 0.4 # must be in the range [0,1]. Only frequencies in the range [max_detectable_frequency * wiggle_frequency_range, max_detectable_frequency] are considered as wiggling. So a value of 0 means that every frequency with an amplitude above wiggle_detection_threshold is detected as wiggling and a value of 1 means that only the max_detectable_frequency can trigger a wiggle detection.      max_detectable_frequency = 1 / (2 * sample_period)
   tf_publisher:

--- a/config/hsr.yaml
+++ b/config/hsr.yaml
@@ -42,7 +42,7 @@ plugins:
     normalize_position: False # centers the joint positions around 0 on the y axis
     tick_stride: 0.5 # the distance between ticks in the plot. if tick_stride <= 0 pyplot determines the ticks automatically
   WiggleCancel: # cancels planning if high frequencies are detected in the trajectory
-    amplitude_threshold: 0.15 # the amplitude of a frequency must exceed this threshold to be detected as wiggling
+    amplitude_threshold: 0.55 # the amplitude of a frequency must exceed this threshold to be detected as wiggling
     window_size: 21 # size of the moving window of sample points
     frequency_range: 0.4 # must be in the range [0,1]. Only frequencies in the range [max_detectable_frequency * wiggle_frequency_range, max_detectable_frequency] are considered as wiggling. So a value of 0 means that every frequency with an amplitude above wiggle_detection_threshold is detected as wiggling and a value of 1 means that only the max_detectable_frequency can trigger a wiggle detection.      max_detectable_frequency = 1 / (2 * sample_period)
   tf_publisher:

--- a/config/kmr_iiwa.yaml
+++ b/config/kmr_iiwa.yaml
@@ -38,7 +38,7 @@ plugins:
     normalize_position: False # centers the joint positions around 0 on the y axis
     tick_stride: 1.0 # the distance between ticks in the plot. if tick_stride <= 0 pyplot determines the ticks automatically 
   WiggleCancel: # cancels planning if high frequencies are detected in the trajectory
-    amplitude_threshold: 0.15 # the amplitude of a frequency must exceed this threshold to be detected as wiggling
+    amplitude_threshold: 0.55 # the amplitude of a frequency must exceed this threshold to be detected as wiggling
     window_size: 21 # size of the moving window of sample points
     frequency_range: 0.4 # must be in the range [0,1]. Only frequencies in the range [max_detectable_frequency * wiggle_frequency_range, max_detectable_frequency] are considered as wiggling. So a value of 0 means that every frequency with an amplitude above wiggle_detection_threshold is detected as wiggling and a value of 1 means that only the max_detectable_frequency can trigger a wiggle detection.      max_detectable_frequency = 1 / (2 * sample_period)
   tf_publisher:

--- a/config/pr2.yaml
+++ b/config/pr2.yaml
@@ -48,7 +48,7 @@ plugins:
     normalize_position: False # centers the joint positions around 0 on the y axis
     tick_stride: 0.5 # the distance between ticks in the plot. if tick_stride <= 0 pyplot determines the ticks automatically
   WiggleCancel: # cancels planning if high frequencies are detected in the trajectory
-    amplitude_threshold: 0.45 # must be in the range [0,1]. The amplitude of a frequency must exceed this threshold to be detected as wiggling.
+    amplitude_threshold: 0.55 # must be in the range [0,1]. The amplitude of a frequency must exceed this threshold to be detected as wiggling.
     window_size: 21 # size of the moving window of sample points
     frequency_range: 0.4 # must be in the range [0,1]. Only frequencies in the range [max_detectable_frequency * wiggle_frequency_range, max_detectable_frequency] are considered as wiggling. So a value of 0 means that every frequency with an amplitude above wiggle_detection_threshold is detected as wiggling and a value of 1 means that only the max_detectable_frequency can trigger a wiggle detection.      max_detectable_frequency = 1 / (2 * sample_period)
   tf_publisher:

--- a/config/pr2.yaml
+++ b/config/pr2.yaml
@@ -48,7 +48,7 @@ plugins:
     normalize_position: False # centers the joint positions around 0 on the y axis
     tick_stride: 0.5 # the distance between ticks in the plot. if tick_stride <= 0 pyplot determines the ticks automatically
   WiggleCancel: # cancels planning if high frequencies are detected in the trajectory
-    amplitude_threshold: 0.6 # must be in the range [0,1]. The amplitude of a frequency must exceed this threshold to be detected as wiggling.
+    amplitude_threshold: 0.45 # must be in the range [0,1]. The amplitude of a frequency must exceed this threshold to be detected as wiggling.
     window_size: 21 # size of the moving window of sample points
     frequency_range: 0.4 # must be in the range [0,1]. Only frequencies in the range [max_detectable_frequency * wiggle_frequency_range, max_detectable_frequency] are considered as wiggling. So a value of 0 means that every frequency with an amplitude above wiggle_detection_threshold is detected as wiggling and a value of 1 means that only the max_detectable_frequency can trigger a wiggle detection.      max_detectable_frequency = 1 / (2 * sample_period)
   tf_publisher:

--- a/config/pr2.yaml
+++ b/config/pr2.yaml
@@ -48,7 +48,7 @@ plugins:
     normalize_position: False # centers the joint positions around 0 on the y axis
     tick_stride: 0.5 # the distance between ticks in the plot. if tick_stride <= 0 pyplot determines the ticks automatically
   WiggleCancel: # cancels planning if high frequencies are detected in the trajectory
-    amplitude_threshold: 0.28 # the amplitude of a frequency must exceed this threshold to be detected as wiggling
+    amplitude_threshold: 0.6 # must be in the range [0,1]. The amplitude of a frequency must exceed this threshold to be detected as wiggling.
     window_size: 21 # size of the moving window of sample points
     frequency_range: 0.4 # must be in the range [0,1]. Only frequencies in the range [max_detectable_frequency * wiggle_frequency_range, max_detectable_frequency] are considered as wiggling. So a value of 0 means that every frequency with an amplitude above wiggle_detection_threshold is detected as wiggling and a value of 1 means that only the max_detectable_frequency can trigger a wiggle detection.      max_detectable_frequency = 1 / (2 * sample_period)
   tf_publisher:

--- a/src/giskardpy/constraints.py
+++ b/src/giskardpy/constraints.py
@@ -752,9 +752,9 @@ class Shaking(Constraint):
         time_in_secs = self.get_input_sampling_period() * time
 
         correct_err = joint_goal - current_joint
-        sin_err = correct_err * w.sin(frequency * 2.0 * w.pi * time_in_secs)
-        cos_err = correct_err * w.cos(frequency * 2.0 * w.pi * time_in_secs)
-        err = w.if_eq(w.fmod(frequency, 7.0), 0.0, sin_err, cos_err)
+        fun_params = frequency * 2.0 * w.pi * time_in_secs
+        shake_err = w.if_eq(w.fmod(frequency, 7.0), 0.0, w.sin(fun_params), w.cos(fun_params))
+        err = correct_err * shake_err
         capped_err = self.limit_velocity(err, max_velocity)
         weight = self.normalize_weight(max_velocity, weight)
         self.add_debug_constraint("time", time_in_secs)

--- a/src/giskardpy/constraints.py
+++ b/src/giskardpy/constraints.py
@@ -710,7 +710,7 @@ class ShakyJointPositionRevoluteOrPrismatic(Constraint):
     frequency = u'frequency'
     noise_amplitude = u'noise_amplitude'
 
-    def __init__(self, god_map, joint_name, goal, frequency, noise_amplitude=10, weight=WEIGHT_BELOW_CA,
+    def __init__(self, god_map, joint_name, goal, frequency, noise_amplitude=1.0, weight=WEIGHT_BELOW_CA,
                  max_velocity=3451, max_acceleration=1, goal_constraint=True):
         """
         This goal will move a revolute or prismatic joint to the goal position and shake the joint with the given frequency.
@@ -761,7 +761,7 @@ class ShakyJointPositionRevoluteOrPrismatic(Constraint):
                              self.get_robot().get_joint_velocity_limit_expr(self.joint_name))
 
         fun_params = frequency * 2.0 * w.pi * time_in_secs
-        err = (joint_goal - current_joint) + w.cos(fun_params)
+        err = (joint_goal - current_joint) + noise_amplitude * max_velocity * w.sin(fun_params)
         capped_err = self.limit_velocity(err, noise_amplitude * max_velocity)
 
         weight = self.normalize_weight(max_velocity, weight)
@@ -837,8 +837,8 @@ class ShakyJointPositionContinuous(Constraint):
                              self.get_robot().get_joint_velocity_limit_expr(self.joint_name))
 
         fun_params = frequency * 2.0 * w.pi * time_in_secs
-        err = w.shortest_angular_distance(current_joint, joint_goal) + noise_amplitude * w.cos(fun_params)
-        capped_err = self.limit_velocity(err, max_velocity)
+        err = w.shortest_angular_distance(current_joint, joint_goal) + noise_amplitude * max_velocity * w.sin(fun_params)
+        capped_err = self.limit_velocity(err, noise_amplitude * max_velocity)
 
         weight = self.normalize_weight(max_velocity, weight)
 

--- a/src/giskardpy/constraints.py
+++ b/src/giskardpy/constraints.py
@@ -761,8 +761,8 @@ class ShakyJointPositionRevoluteOrPrismatic(Constraint):
                              self.get_robot().get_joint_velocity_limit_expr(self.joint_name))
 
         fun_params = frequency * 2.0 * w.pi * time_in_secs
-        err = (joint_goal - current_joint) + noise_amplitude * w.cos(fun_params)
-        capped_err = self.limit_velocity(err, max_velocity)
+        err = (joint_goal - current_joint) + w.cos(fun_params)
+        capped_err = self.limit_velocity(err, noise_amplitude * max_velocity)
 
         weight = self.normalize_weight(max_velocity, weight)
 

--- a/src/giskardpy/constraints.py
+++ b/src/giskardpy/constraints.py
@@ -748,7 +748,7 @@ class Shaking(Constraint):
         time_in_secs = self.get_input_sampling_period() * time
 
         fun_params = frequency * 2.0 * w.pi * time_in_secs
-        err = w.if_eq(w.fmod(frequency, 7.0), 0.0, w.sin(fun_params), w.cos(fun_params))
+        err = w.cos(fun_params)
         capped_err = self.limit_velocity(err, max_velocity)
         weight = self.normalize_weight(max_velocity, weight)
         self.add_constraint(u'',

--- a/src/giskardpy/constraints.py
+++ b/src/giskardpy/constraints.py
@@ -702,7 +702,7 @@ class JointPositionRevolute(Constraint):
         return u'{}/{}'.format(s, self.joint_name)
 
 
-class ShakeyJointPositionRevoluteOrPrismatic(Constraint):
+class ShakyJointPositionRevoluteOrPrismatic(Constraint):
     goal = u'goal'
     weight = u'weight'
     max_velocity = u'max_velocity'
@@ -713,7 +713,7 @@ class ShakeyJointPositionRevoluteOrPrismatic(Constraint):
     def __init__(self, god_map, joint_name, goal, frequency, noise_amplitude=10, weight=WEIGHT_BELOW_CA,
                  max_velocity=3451, max_acceleration=1, goal_constraint=True):
         """
-        This goal will move a revolute joint to the goal position and shake the joint with the given frequency.
+        This goal will move a revolute or prismatic joint to the goal position and shake the joint with the given frequency.
         :param joint_name: str
         :param goal: float
         :param frequency: float
@@ -721,7 +721,7 @@ class ShakeyJointPositionRevoluteOrPrismatic(Constraint):
         :param weight: float, default WEIGHT_BELOW_CA
         :param max_velocity: float, rad/s, default 3451, meaning the urdf/config limits are active
         """
-        super(ShakeyJointPositionRevoluteOrPrismatic, self).__init__(god_map)
+        super(ShakyJointPositionRevoluteOrPrismatic, self).__init__(god_map)
         self.joint_name = joint_name
         self.goal_constraint = goal_constraint
         if not self.get_robot().is_joint_revolute(joint_name) and not self.get_robot().is_joint_prismatic(joint_name):
@@ -739,14 +739,13 @@ class ShakeyJointPositionRevoluteOrPrismatic(Constraint):
     def make_constraints(self):
         """
         example:
-        name='JointPosition'
+        name='ShakyJointPositionRevoluteOrPrismatic'
         parameter_value_pair='{
             "joint_name": "r_wrist_flex_joint", #required
-            "goal_position": 0, #required
-            "frequency": 0, #required
+            "goal_position": -1.0, #required
+            "frequency": 5.0, #required
             "weight": 1, #optional
-            "gain": 10, #optional -- error is multiplied with this value
-            "max_speed": 1 #optional -- rad/s or m/s depending on joint; can not go higher than urdf limit
+            "max_velocity": 1 #optional -- rad/s or m/s depending on joint; can not go higher than urdf limit
         }'
         :return:
         """
@@ -775,10 +774,10 @@ class ShakeyJointPositionRevoluteOrPrismatic(Constraint):
                             goal_constraint=self.goal_constraint)
 
     def __str__(self):
-        s = super(ShakeyJointPositionRevoluteOrPrismatic, self).__str__()
+        s = super(ShakyJointPositionRevoluteOrPrismatic, self).__str__()
         return u'{}/{}'.format(s, self.joint_name)
 
-class ShakeyJointPositionContinuous(Constraint):
+class ShakyJointPositionContinuous(Constraint):
     goal = u'goal'
     weight = u'weight'
     max_velocity = u'max_velocity'
@@ -790,7 +789,7 @@ class ShakeyJointPositionContinuous(Constraint):
     def __init__(self, god_map, joint_name, goal, frequency, noise_amplitude=10, weight=WEIGHT_BELOW_CA,
                  max_velocity=3451, max_acceleration=1, goal_constraint=True):
         """
-        This goal will move a revolute joint to the goal position and shake the joint with the given frequency.
+        This goal will move a continuous joint to the goal position and shake the joint with the given frequency.
         :param joint_name: str
         :param goal: float
         :param frequency: float
@@ -798,7 +797,7 @@ class ShakeyJointPositionContinuous(Constraint):
         :param weight: float, default WEIGHT_BELOW_CA
         :param max_velocity: float, rad/s, default 3451, meaning the urdf/config limits are active
         """
-        super(ShakeyJointPositionContinuous, self).__init__(god_map)
+        super(ShakyJointPositionContinuous, self).__init__(god_map)
         self.joint_name = joint_name
         self.goal_constraint = goal_constraint
         if not self.get_robot().is_joint_continuous(joint_name):
@@ -818,12 +817,11 @@ class ShakeyJointPositionContinuous(Constraint):
         example:
         name='JointPosition'
         parameter_value_pair='{
-            "joint_name": "r_wrist_flex_joint", #required
-            "goal_position": 0, #required
-            "frequency": 0, #required
+            "joint_name": "l_wrist_roll_joint", #required
+            "goal_position": -5.0, #required
+            "frequency": 5.0, #required
             "weight": 1, #optional
-            "gain": 10, #optional -- error is multiplied with this value
-            "max_speed": 1 #optional -- rad/s or m/s depending on joint; can not go higher than urdf limit
+            "max_velocity": 1 #optional -- rad/s or m/s depending on joint; can not go higher than urdf limit
         }'
         :return:
         """
@@ -852,7 +850,7 @@ class ShakeyJointPositionContinuous(Constraint):
                             goal_constraint=self.goal_constraint)
 
     def __str__(self):
-        s = super(ShakeyJointPositionContinuous, self).__str__()
+        s = super(ShakyJointPositionContinuous, self).__str__()
         return u'{}/{}'.format(s, self.joint_name)
 
 class AvoidJointLimitsRevolute(Constraint):

--- a/src/giskardpy/plugin_interrupts.py
+++ b/src/giskardpy/plugin_interrupts.py
@@ -103,7 +103,7 @@ class WiggleCancel(GiskardBehavior):
             return False
 
         fft = np.fft.rfft(joints_filtered, axis=1)
-        fft = [np.abs(i.real) for i in fft]
+        fft = [np.sqrt(i.imag**2 + i.real**2) for i in fft]
 
         if plot:
             y = joints_filtered

--- a/src/giskardpy/plugin_interrupts.py
+++ b/src/giskardpy/plugin_interrupts.py
@@ -86,7 +86,7 @@ class WiggleCancel(GiskardBehavior):
         # remove joints that arent moving
         mask = self.make_mask(js_samples, moving_thresholds)
         velocity_limits = velocity_limits[mask]
-        amplitude_thresholds = velocity_limits * amplitude_threshold * N  # acceleration limit is basically vel*2
+        amplitude_thresholds = velocity_limits * amplitude_threshold  # acceleration limit is basically vel*2
         joints_filtered = js_samples[mask]
         joints_filtered = np.diff(joints_filtered)
         # joints_filtered = (joints_filtered.T - joints_filtered.mean(axis=1)).T
@@ -103,8 +103,7 @@ class WiggleCancel(GiskardBehavior):
             return False
 
         fft = np.fft.rfft(joints_filtered, axis=1)
-        fft = [np.sqrt(i.imag**2 + i.real**2) for i in fft]
-
+        fft = [np.abs(i/N) for i in fft]# amplitude of fft is only half as big ?!?!?
         if plot:
             y = joints_filtered
 
@@ -134,7 +133,7 @@ class WiggleCancel(GiskardBehavior):
                     joint = filtered_keys[i]
                     velocity_limit = velocity_limits[i]
                     hertz_str = u', '.join(u'{} hertz: {} > {}'.format(freq[freq_idx:][j],
-                                                                     fft[:, freq_idx:].T[:, i][j] / N / velocity_limit,
+                                                                     fft[:, freq_idx:].T[:, i][j] / velocity_limit,
                                                                      amplitude_threshold) for j, x in
                                          enumerate(violations[:, i]) if x)
                     violation_str += u'\nshaking of joint: \'{}\' at '.format(joint) + hertz_str

--- a/src/giskardpy/plugin_interrupts.py
+++ b/src/giskardpy/plugin_interrupts.py
@@ -103,7 +103,7 @@ class WiggleCancel(GiskardBehavior):
             return False
 
         fft = np.fft.rfft(joints_filtered, axis=1)
-        fft = [np.abs(i/N) for i in fft]# amplitude of fft is only half as big ?!?!?
+        fft = [2.0 * np.abs(i)/N for i in fft]
         if plot:
             y = joints_filtered
 
@@ -123,7 +123,7 @@ class WiggleCancel(GiskardBehavior):
                 # plt.plot(xf, np.abs(yf.imag), label=u'img')
             plt.show()
 
-        fft = np.array(fft)
+        fft = (velocity_limits * np.array(fft).T).T
         violations = fft[:, freq_idx:].T > amplitude_thresholds
         if np.any(violations):
             filtered_keys = self.keys[mask]

--- a/test/test_integration_pr2.py
+++ b/test/test_integration_pr2.py
@@ -1,5 +1,6 @@
 from __future__ import division
 
+import re
 import itertools
 from copy import deepcopy
 
@@ -25,7 +26,6 @@ from giskardpy.utils import to_joint_state_position_dict, publish_marker_vector
 from rospy_message_converter.message_converter import convert_dictionary_to_ros_message
 from utils_for_tests import PR2, compare_poses
 from iai_naive_kinematics_sim.srv import UpdateTransform
-
 
 # TODO roslaunch iai_pr2_sim ros_control_sim_with_base.launch
 # TODO roslaunch iai_kitchen upload_kitchen_obj.launch
@@ -399,16 +399,15 @@ class TestConstraints(object):
         zero_pose.set_straight_cart_goal(goal_position, zero_pose.l_tip)
         zero_pose.send_and_check_goal()
 
-
     def test_CartesianVelocityLimit(self, zero_pose):
         linear_velocity = 1
         angular_velocity = 1
         zero_pose.limit_cartesian_velocity(
-                                root_link=zero_pose.default_root,
-                                tip_link=u'base_footprint',
-                                max_linear_velocity=0.1,
-                                max_angular_velocity=0.2
-                                )
+            root_link=zero_pose.default_root,
+            tip_link=u'base_footprint',
+            max_linear_velocity=0.1,
+            max_angular_velocity=0.2
+        )
         goal_position = PoseStamped()
         goal_position.header.frame_id = u'r_gripper_tool_frame'
         goal_position.pose.position.x = 1
@@ -421,7 +420,6 @@ class TestConstraints(object):
                                           angular_velocity=angular_velocity,
                                           weight=WEIGHT_BELOW_CA
                                           )
-
 
     def test_AvoidJointLimits1(self, zero_pose):
         """
@@ -840,7 +838,7 @@ class TestConstraints(object):
         # kitchen_setup.allow_all_collisions()
         kitchen_setup.set_json_goal(u'AvoidJointLimits', percentage=percentage)
         kitchen_setup.limit_cartesian_velocity(u'odom_combined', u'base_footprint', max_linear_velocity=0.1,
-                                                       max_angular_velocity=0.2)
+                                               max_angular_velocity=0.2)
         kitchen_setup.send_and_check_goal()
 
         kitchen_setup.set_json_goal(u'OpenDoor',
@@ -1105,11 +1103,11 @@ class TestConstraints(object):
         tip_grasp_axis.vector.z = 1
 
         kitchen_setup.grasp_bar(root_link=kitchen_setup.default_root,
-                                    tip_link=kitchen_setup.r_tip,
-                                    tip_grasp_axis=tip_grasp_axis,
-                                    bar_center=bar_center,
-                                    bar_axis=bar_axis,
-                                    bar_length=.3)
+                                tip_link=kitchen_setup.r_tip,
+                                tip_grasp_axis=tip_grasp_axis,
+                                bar_center=bar_center,
+                                bar_axis=bar_axis,
+                                bar_length=.3)
         kitchen_setup.allow_collision([], u'kitchen', [u'sink_area_dish_washer_door_handle'])
         # kitchen_setup.allow_all_collisions()
         kitchen_setup.send_and_check_goal()
@@ -1455,6 +1453,27 @@ class TestCartGoals(object):
         zero_pose.send_and_check_goal()
         zero_pose.check_cart_goal(zero_pose.r_tip, r_goal)
         zero_pose.check_cart_goal(zero_pose.l_tip, l_goal)
+
+    def test_wiggle_shaking(self, kitchen_setup):
+        sample_period = kitchen_setup.get_god_map().get_data(identifier.sample_period)
+        frequency_range = kitchen_setup.get_god_map().get_data(identifier.frequency_range)
+        max_detectable_freq = int(1 / (2 * sample_period))
+        min_wiggle_frequency = int(frequency_range * max_detectable_freq)
+        distance_between_frequencies = 5 if sample_period < 0.05 else 1
+
+        for f in range(min_wiggle_frequency, max_detectable_freq+1, distance_between_frequencies):
+            target_freq = float(f)
+            kitchen_setup.set_json_goal(u'Shaking',
+                                        joint_name=u'torso_lift_joint',
+                                        frequency=target_freq
+                                        )
+            r = kitchen_setup.send_goal(goal=None, goal_type=MoveGoal.PLAN_AND_EXECUTE)
+            assert len(r.error_codes) != 0
+            error_code = r.error_codes[0]
+            assert error_code == MoveResult.SHAKING
+            error_message = r.error_messages[0]
+            freq_str = re.search("at [0-9]+\.[0-9]+ hertz", error_message).group(0)
+            assert float(freq_str[3:-6]) == target_freq
 
     def test_wiggle1(self, kitchen_setup):
         tray_pose = PoseStamped()
@@ -7419,9 +7438,9 @@ class TestCollisionAvoidanceGoals(object):
         pot_pose = PoseStamped()
         pot_pose.header.frame_id = u'lid'
         pot_pose.pose.position.z = -0.22
-        pot_pose.pose.orientation = Quaternion(*quaternion_about_axis(np.pi/2, [0,0,1]))
+        pot_pose.pose.orientation = Quaternion(*quaternion_about_axis(np.pi / 2, [0, 0, 1]))
         kitchen_setup.add_mesh(object_name, path=u'package://cad_models/kitchen/cooking-vessels/cookingpot.dae',
-                           pose=pot_pose)
+                               pose=pot_pose)
 
         base_pose = PoseStamped()
         base_pose.header.frame_id = u'iai_kitchen/table_area_main'
@@ -7438,7 +7457,6 @@ class TestCollisionAvoidanceGoals(object):
         # kitchen_setup.avoid_collision([], 'kitchen', ['table_area_main'], 0.05)
         kitchen_setup.set_cart_goal(hand_goal, u'r_gripper_tool_frame')
         kitchen_setup.send_goal(goal_type=MoveGoal.PLAN_ONLY)
-
 
         # kitchen_setup.add_cylinder('pot', size=[0.2,0.2], pose=pot_pose)
 

--- a/test/test_integration_pr2.py
+++ b/test/test_integration_pr2.py
@@ -1977,17 +1977,17 @@ class TestShaking(object):
             min_wiggle_frequency += 1
         distance_between_frequencies = 5
 
-        for joint in [u'r_wrist_flex_joint', u'head_pan_joint']:  # max vel: 1.0 and 0.5
-            for f in range(min_wiggle_frequency, max_detectable_freq + 1, distance_between_frequencies):
+        for joint in [ u'head_pan_joint', u'r_wrist_flex_joint']:  # max vel: 1.0 and 0.5
+            for f in range(min_wiggle_frequency, max_detectable_freq, distance_between_frequencies):
                 kitchen_setup.set_json_goal(u'JointPositionRevolute',
                                             joint_name=joint,
-                                            goal=0.0,
+                                            goal=0.5,
                                             )
                 kitchen_setup.send_goal()
                 target_freq = float(f)
                 kitchen_setup.set_json_goal(u'ShakyJointPositionRevoluteOrPrismatic',
                                             joint_name=joint,
-                                            goal=1.0,
+                                            goal=0.0,
                                             frequency=target_freq
                                             )
                 r = kitchen_setup.send_goal(goal=None, goal_type=MoveGoal.PLAN_AND_EXECUTE)
@@ -2007,17 +2007,17 @@ class TestShaking(object):
             min_wiggle_frequency += 1
         distance_between_frequencies = 5
 
-        for joint in [u'torso_lift_joint']: #, u'odom_x_joint']: # max vel: 0.015 and 0.5
+        for joint in [u'odom_x_joint']: #, u'torso_lift_joint']: # max vel: 0.015 and 0.5
             for f in range(min_wiggle_frequency, max_detectable_freq, distance_between_frequencies):
                 kitchen_setup.set_json_goal(u'JointPositionPrismatic',
                                             joint_name=joint,
-                                            goal=0.0,
+                                            goal=0.02,
                                             )
                 kitchen_setup.send_goal()
                 target_freq = float(f)
                 kitchen_setup.set_json_goal(u'ShakyJointPositionRevoluteOrPrismatic',
                                             joint_name=joint,
-                                            goal=2.0,
+                                            goal=0.0,
                                             frequency=target_freq
                                             )
                 r = kitchen_setup.send_goal(goal=None, goal_type=MoveGoal.PLAN_AND_EXECUTE)

--- a/test/test_integration_pr2.py
+++ b/test/test_integration_pr2.py
@@ -1461,10 +1461,10 @@ class TestCartGoals(object):
         min_wiggle_frequency = int(frequency_range * max_detectable_freq)
         distance_between_frequencies = 5 if sample_period < 0.05 else 1
 
-        for f in range(min_wiggle_frequency, max_detectable_freq+1, distance_between_frequencies):
+        for f in range(min_wiggle_frequency, max_detectable_freq + 1, distance_between_frequencies):
             target_freq = float(f)
             kitchen_setup.set_json_goal(u'Shaking',
-                                        joint_name=u'torso_lift_joint',
+                                        joint_name=u'odom_x_joint',
                                         frequency=target_freq
                                         )
             r = kitchen_setup.send_goal(goal=None, goal_type=MoveGoal.PLAN_AND_EXECUTE)
@@ -1472,8 +1472,8 @@ class TestCartGoals(object):
             error_code = r.error_codes[0]
             assert error_code == MoveResult.SHAKING
             error_message = r.error_messages[0]
-            freq_str = re.search("at [0-9]+\.[0-9]+ hertz", error_message).group(0)
-            assert float(freq_str[3:-6]) == target_freq
+            freqs_str = re.findall("[0-9]+\.[0-9]+ hertz", error_message)
+            assert any(map(lambda f_str: float(f_str[:-6]) == target_freq, freqs_str))
 
     def test_wiggle1(self, kitchen_setup):
         tray_pose = PoseStamped()

--- a/test/test_integration_pr2.py
+++ b/test/test_integration_pr2.py
@@ -233,7 +233,6 @@ def kitchen_setup(resetted_giskard):
     resetted_giskard.allow_all_collisions()
     resetted_giskard.send_and_check_joint_goal(gaya_pose)
     object_name = u'kitchen'
-    # TODO: wait for kitchen param from the ros param server
     resetted_giskard.add_urdf(object_name, rospy.get_param(u'kitchen_description'),
                               tf.lookup_pose(u'map', u'iai_kitchen/world'), u'/kitchen/joint_states',
                               set_js_topic=u'/kitchen/cram_joint_states')

--- a/test/test_integration_pr2.py
+++ b/test/test_integration_pr2.py
@@ -1541,26 +1541,130 @@ class TestCartGoals(object):
         rospy.logerr(res)
         assert True
 
-    def test_wiggle_shaking(self, kitchen_setup):
+    def test_wiggle_prismatic_joint_neglectable_shaking(self, kitchen_setup):
         sample_period = kitchen_setup.get_god_map().get_data(identifier.sample_period)
         frequency_range = kitchen_setup.get_god_map().get_data(identifier.frequency_range)
         max_detectable_freq = int(1 / (2 * sample_period))
         min_wiggle_frequency = int(frequency_range * max_detectable_freq)
         distance_between_frequencies = 5 if sample_period < 0.05 else 1
 
-        for f in range(min_wiggle_frequency, max_detectable_freq + 1, distance_between_frequencies):
-            target_freq = float(f)
-            kitchen_setup.set_json_goal(u'Shaking',
-                                        joint_name=u'odom_x_joint',
-                                        frequency=target_freq
-                                        )
-            r = kitchen_setup.send_goal(goal=None, goal_type=MoveGoal.PLAN_AND_EXECUTE)
-            assert len(r.error_codes) != 0
-            error_code = r.error_codes[0]
-            assert error_code == MoveResult.SHAKING
-            error_message = r.error_messages[0]
-            freqs_str = re.findall("[0-9]+\.[0-9]+ hertz", error_message)
-            assert any(map(lambda f_str: float(f_str[:-6]) == target_freq, freqs_str))
+        for joint, noise_amplitude, goal in [(u'torso_lift_joint', 0.01, 0.05), (u'odom_x_joint', 0.005, 0.5)]:# max vel: 0.015 and 0.5
+            for f in range(min_wiggle_frequency, max_detectable_freq + 1, distance_between_frequencies):
+                target_freq = float(f)
+                kitchen_setup.set_json_goal(u'JointPositionPrismatic',
+                                            joint_name=joint,
+                                            goal=0.0,
+                                            )
+                kitchen_setup.send_goal()
+                kitchen_setup.set_json_goal(u'ShakeyJointPositionRevoluteOrPrismatic',
+                                            joint_name=joint,
+                                            noise_amplitude=noise_amplitude,
+                                            goal=goal,
+                                            frequency=target_freq
+                                            )
+                kitchen_setup.send_and_check_goal()
+
+    def test_wiggle_revolute_joint_neglectable_shaking(self, kitchen_setup):
+        sample_period = kitchen_setup.get_god_map().get_data(identifier.sample_period)
+        frequency_range = kitchen_setup.get_god_map().get_data(identifier.frequency_range)
+        max_detectable_freq = int(1 / (2 * sample_period))
+        min_wiggle_frequency = int(frequency_range * max_detectable_freq)
+        distance_between_frequencies = 5 if sample_period < 0.05 else 1
+
+        for joint, noise_amplitude in [(u'r_wrist_flex_joint', 0.01), (u'head_pan_joint', 0.005)]:  # max vel: 1.0 and 0.5
+            for f in range(min_wiggle_frequency, max_detectable_freq + 1, distance_between_frequencies):
+                target_freq = float(f)
+                kitchen_setup.set_json_goal(u'JointPositionRevolute',
+                                            joint_name=joint,
+                                            goal=0.0,
+                                            )
+                kitchen_setup.send_goal()
+                kitchen_setup.set_json_goal(u'ShakeyJointPositionRevoluteOrPrismatic',
+                                            joint_name=joint,
+                                            noise_amplitude=noise_amplitude,
+                                            goal=1.0,
+                                            frequency=target_freq
+                                            )
+                kitchen_setup.send_and_check_goal()
+
+    def test_wiggle_revolute_joint_shaking(self, kitchen_setup):
+        sample_period = kitchen_setup.get_god_map().get_data(identifier.sample_period)
+        frequency_range = kitchen_setup.get_god_map().get_data(identifier.frequency_range)
+        max_detectable_freq = int(1 / (2 * sample_period))
+        min_wiggle_frequency = int(frequency_range * max_detectable_freq)
+        distance_between_frequencies = 5 if sample_period < 0.05 else 1
+
+        for joint in [u'r_wrist_flex_joint', u'head_pan_joint']: # max vel: 1.0 and 0.5
+            for f in range(min_wiggle_frequency, max_detectable_freq + 1, distance_between_frequencies):
+                kitchen_setup.set_json_goal(u'JointPositionRevolute',
+                                            joint_name=joint,
+                                            goal=0.0,
+                                            )
+                kitchen_setup.send_goal()
+                target_freq = float(f)
+                kitchen_setup.set_json_goal(u'ShakeyJointPositionRevoluteOrPrismatic',
+                                            joint_name=joint,
+                                            goal=1.0,
+                                            frequency=target_freq
+                                            )
+                r = kitchen_setup.send_goal(goal=None, goal_type=MoveGoal.PLAN_AND_EXECUTE)
+                assert len(r.error_codes) != 0
+                error_code = r.error_codes[0]
+                assert error_code == MoveResult.SHAKING
+                error_message = r.error_messages[0]
+                freqs_str = re.findall("[0-9]+\.[0-9]+ hertz", error_message)
+                assert any(map(lambda f_str: float(f_str[:-6]) == target_freq, freqs_str))
+
+    def test_wiggle_prismatic_joint_shaking(self, kitchen_setup):
+        sample_period = kitchen_setup.get_god_map().get_data(identifier.sample_period)
+        frequency_range = kitchen_setup.get_god_map().get_data(identifier.frequency_range)
+        max_detectable_freq = int(1 / (2 * sample_period))
+        min_wiggle_frequency = int(frequency_range * max_detectable_freq)
+        distance_between_frequencies = 5 if sample_period < 0.05 else 1
+
+        for joint in [u'torso_lift_joint', u'odom_x_joint']: # max vel: 0.015 and 0.5
+            for f in range(min_wiggle_frequency, max_detectable_freq + 1, distance_between_frequencies):
+                kitchen_setup.set_json_goal(u'JointPositionPrismatic',
+                                            joint_name=joint,
+                                            goal=0.0,
+                                            )
+                kitchen_setup.send_goal()
+                target_freq = float(f)
+                kitchen_setup.set_json_goal(u'ShakeyJointPositionRevoluteOrPrismatic',
+                                            joint_name=joint,
+                                            goal=1.0,
+                                            frequency=target_freq
+                                            )
+                r = kitchen_setup.send_goal(goal=None, goal_type=MoveGoal.PLAN_AND_EXECUTE)
+                assert len(r.error_codes) != 0
+                error_code = r.error_codes[0]
+                assert error_code == MoveResult.SHAKING
+                error_message = r.error_messages[0]
+                freqs_str = re.findall("[0-9]+\.[0-9]+ hertz", error_message)
+                assert any(map(lambda f_str: float(f_str[:-6]) == target_freq, freqs_str))
+
+    def test_wiggle_continuous_joint_shaking(self, kitchen_setup):
+        sample_period = kitchen_setup.get_god_map().get_data(identifier.sample_period)
+        frequency_range = kitchen_setup.get_god_map().get_data(identifier.frequency_range)
+        max_detectable_freq = int(1 / (2 * sample_period))
+        min_wiggle_frequency = int(frequency_range * max_detectable_freq)
+        distance_between_frequencies = 5 if sample_period < 0.05 else 1
+
+        for continuous_joint in [u'l_wrist_roll_joint', u'r_forearm_roll_joint']:#max vel. of 1.0 and 1.0
+            for f in range(min_wiggle_frequency, max_detectable_freq + 1, distance_between_frequencies):
+                target_freq = float(f)
+                kitchen_setup.set_json_goal(u'ShakeyJointPositionContinuous',
+                                            joint_name=continuous_joint,
+                                            goal=-5.0,
+                                            frequency=target_freq
+                                            )
+                r = kitchen_setup.send_goal(goal=None, goal_type=MoveGoal.PLAN_AND_EXECUTE)
+                assert len(r.error_codes) != 0
+                error_code = r.error_codes[0]
+                assert error_code == MoveResult.SHAKING
+                error_message = r.error_messages[0]
+                freqs_str = re.findall("[0-9]+\.[0-9]+ hertz", error_message)
+                assert any(map(lambda f_str: float(f_str[:-6]) == target_freq, freqs_str))
 
     def test_wiggle1(self, kitchen_setup):
         tray_pose = PoseStamped()

--- a/test/test_integration_pr2.py
+++ b/test/test_integration_pr2.py
@@ -1891,17 +1891,18 @@ class TestShaking(object):
     def test_wiggle_prismatic_joint_neglectable_shaking(self, kitchen_setup):
         sample_period = kitchen_setup.get_god_map().get_data(identifier.sample_period)
         frequency_range = kitchen_setup.get_god_map().get_data(identifier.frequency_range)
+        amplitude_threshold = kitchen_setup.get_god_map().get_data(identifier.amplitude_threshold)
         max_detectable_freq = int(1 / (2 * sample_period))
         min_wiggle_frequency = int(frequency_range * max_detectable_freq)
-        distance_between_frequencies = 5 if sample_period < 0.05 else 1
-        noise_amplitudes = [0.001, 0.002] if sample_period < 0.05 else [0.01, 0.005]
+        while np.fmod(min_wiggle_frequency, 5.0) != 0.0:
+            min_wiggle_frequency += 1
+        distance_between_frequencies = 5
 
         for i, t in enumerate([(u'torso_lift_joint', 0.05), (u'odom_x_joint', 0.5)]):  # max vel: 0.015 and 0.5
-            for f in range(min_wiggle_frequency, max_detectable_freq + 1, distance_between_frequencies):
+            for f in range(min_wiggle_frequency, max_detectable_freq, distance_between_frequencies):
                 target_freq = float(f)
                 joint = t[0]
                 goal = t[1]
-                noise_amplitude = noise_amplitudes[i]
                 kitchen_setup.set_json_goal(u'JointPositionPrismatic',
                                             joint_name=joint,
                                             goal=0.0,
@@ -1909,7 +1910,7 @@ class TestShaking(object):
                 kitchen_setup.send_goal()
                 kitchen_setup.set_json_goal(u'ShakyJointPositionRevoluteOrPrismatic',
                                             joint_name=joint,
-                                            noise_amplitude=noise_amplitude,
+                                            noise_amplitude=amplitude_threshold - 0.05,
                                             goal=goal,
                                             frequency=target_freq
                                             )
@@ -1918,15 +1919,16 @@ class TestShaking(object):
     def test_wiggle_revolute_joint_neglectable_shaking(self, kitchen_setup):
         sample_period = kitchen_setup.get_god_map().get_data(identifier.sample_period)
         frequency_range = kitchen_setup.get_god_map().get_data(identifier.frequency_range)
+        amplitude_threshold = kitchen_setup.get_god_map().get_data(identifier.amplitude_threshold)
         max_detectable_freq = int(1 / (2 * sample_period))
         min_wiggle_frequency = int(frequency_range * max_detectable_freq)
-        distance_between_frequencies = 5 if sample_period < 0.05 else 1
-        noise_amplitudes = [0.7, 0.75] if sample_period < 0.05 else [0.01, 0.005]
+        while np.fmod(min_wiggle_frequency, 5.0) != 0.0:
+            min_wiggle_frequency += 1
+        distance_between_frequencies = 5
 
         for i, joint in enumerate([u'r_wrist_flex_joint', u'head_pan_joint']):  # max vel: 1.0 and 0.5
-            for f in range(min_wiggle_frequency, max_detectable_freq + 1, distance_between_frequencies):
+            for f in range(min_wiggle_frequency, max_detectable_freq, distance_between_frequencies):
                 target_freq = float(f)
-                noise_amplitude = noise_amplitudes[i]
                 kitchen_setup.set_json_goal(u'JointPositionRevolute',
                                             joint_name=joint,
                                             goal=0.0,
@@ -1934,7 +1936,7 @@ class TestShaking(object):
                 kitchen_setup.send_goal()
                 kitchen_setup.set_json_goal(u'ShakyJointPositionRevoluteOrPrismatic',
                                             joint_name=joint,
-                                            noise_amplitude=noise_amplitude,
+                                            noise_amplitude=amplitude_threshold - 0.05,
                                             goal=-1.0,
                                             frequency=target_freq
                                             )
@@ -1943,13 +1945,15 @@ class TestShaking(object):
     def test_wiggle_continuous_joint_neglectable_shaking(self, kitchen_setup):
         sample_period = kitchen_setup.get_god_map().get_data(identifier.sample_period)
         frequency_range = kitchen_setup.get_god_map().get_data(identifier.frequency_range)
+        amplitude_threshold = kitchen_setup.get_god_map().get_data(identifier.amplitude_threshold)
         max_detectable_freq = int(1 / (2 * sample_period))
         min_wiggle_frequency = int(frequency_range * max_detectable_freq)
-        distance_between_frequencies = 5 if sample_period < 0.05 else 1
-        noise_amplitude = 1.0 if sample_period < 0.05 else 0.1
+        while np.fmod(min_wiggle_frequency, 5.0) != 0.0:
+            min_wiggle_frequency += 1
+        distance_between_frequencies = 5
 
         for continuous_joint in [u'l_wrist_roll_joint', u'r_forearm_roll_joint']:  # max vel. of 1.0 and 1.0
-            for f in range(min_wiggle_frequency, max_detectable_freq + 1, distance_between_frequencies):
+            for f in range(min_wiggle_frequency, max_detectable_freq, distance_between_frequencies):
                 kitchen_setup.set_json_goal(u'JointPositionContinuous',
                                             joint_name=continuous_joint,
                                             goal=5.0,
@@ -1959,7 +1963,7 @@ class TestShaking(object):
                 kitchen_setup.set_json_goal(u'ShakyJointPositionContinuous',
                                             joint_name=continuous_joint,
                                             goal=-5.0,
-                                            noise_amplitude=noise_amplitude,
+                                            noise_amplitude=amplitude_threshold - 0.05,
                                             frequency=target_freq
                                             )
                 kitchen_setup.send_and_check_goal()
@@ -1969,7 +1973,9 @@ class TestShaking(object):
         frequency_range = kitchen_setup.get_god_map().get_data(identifier.frequency_range)
         max_detectable_freq = int(1 / (2 * sample_period))
         min_wiggle_frequency = int(frequency_range * max_detectable_freq)
-        distance_between_frequencies = 5 if sample_period < 0.05 else 1
+        while np.fmod(min_wiggle_frequency, 5.0) != 0.0:
+            min_wiggle_frequency += 1
+        distance_between_frequencies = 5
 
         for joint in [u'r_wrist_flex_joint', u'head_pan_joint']:  # max vel: 1.0 and 0.5
             for f in range(min_wiggle_frequency, max_detectable_freq + 1, distance_between_frequencies):
@@ -1997,10 +2003,12 @@ class TestShaking(object):
         frequency_range = kitchen_setup.get_god_map().get_data(identifier.frequency_range)
         max_detectable_freq = int(1 / (2 * sample_period))
         min_wiggle_frequency = int(frequency_range * max_detectable_freq)
-        distance_between_frequencies = 5 if sample_period < 0.05 else 1
+        while np.fmod(min_wiggle_frequency, 5.0) != 0.0:
+            min_wiggle_frequency += 1
+        distance_between_frequencies = 5
 
-        for joint in [u'torso_lift_joint', u'odom_x_joint']:  # max vel: 0.015 and 0.5
-            for f in range(min_wiggle_frequency, max_detectable_freq + 1, distance_between_frequencies):
+        for joint in [u'torso_lift_joint']: #, u'odom_x_joint']: # max vel: 0.015 and 0.5
+            for f in range(min_wiggle_frequency, max_detectable_freq, distance_between_frequencies):
                 kitchen_setup.set_json_goal(u'JointPositionPrismatic',
                                             joint_name=joint,
                                             goal=0.0,
@@ -2009,7 +2017,7 @@ class TestShaking(object):
                 target_freq = float(f)
                 kitchen_setup.set_json_goal(u'ShakyJointPositionRevoluteOrPrismatic',
                                             joint_name=joint,
-                                            goal=1.0,
+                                            goal=2.0,
                                             frequency=target_freq
                                             )
                 r = kitchen_setup.send_goal(goal=None, goal_type=MoveGoal.PLAN_AND_EXECUTE)
@@ -2025,10 +2033,12 @@ class TestShaking(object):
         frequency_range = kitchen_setup.get_god_map().get_data(identifier.frequency_range)
         max_detectable_freq = int(1 / (2 * sample_period))
         min_wiggle_frequency = int(frequency_range * max_detectable_freq)
-        distance_between_frequencies = 5 if sample_period < 0.05 else 1
+        while np.fmod(min_wiggle_frequency, 5.0) != 0.0:
+            min_wiggle_frequency += 1
+        distance_between_frequencies = 5
 
         for continuous_joint in [u'l_wrist_roll_joint', u'r_forearm_roll_joint']:  # max vel. of 1.0 and 1.0
-            for f in range(min_wiggle_frequency, max_detectable_freq + 1, distance_between_frequencies):
+            for f in range(min_wiggle_frequency, max_detectable_freq, distance_between_frequencies):
                 kitchen_setup.set_json_goal(u'JointPositionContinuous',
                                             joint_name=continuous_joint,
                                             goal=5.0,
@@ -2054,10 +2064,12 @@ class TestShaking(object):
         amplitude_threshold = kitchen_setup.get_god_map().get_data(identifier.amplitude_threshold)
         max_detectable_freq = int(1 / (2 * sample_period))
         min_wiggle_frequency = int(frequency_range * max_detectable_freq)
-        distance_between_frequencies = 5 if sample_period < 0.05 else 1
+        while np.fmod(min_wiggle_frequency, 5.0) != 0.0:
+            min_wiggle_frequency += 1
+        distance_between_frequencies = 5
 
         for revolute_joint in [u'r_wrist_flex_joint', u'head_pan_joint']:  # max vel. of 1.0 and 1.0
-            for f in range(5, 5 + 1, distance_between_frequencies): # todo: with 5, and 10 hertz
+            for f in range(min_wiggle_frequency, max_detectable_freq, distance_between_frequencies):
                 target_freq = float(f)
 
                 if f == min_wiggle_frequency:
@@ -2070,7 +2082,7 @@ class TestShaking(object):
                 kitchen_setup.set_json_goal(u'ShakyJointPositionRevoluteOrPrismatic',
                                             joint_name=revolute_joint,
                                             goal=0.0,
-                                            noise_amplitude=amplitude_threshold + 0.05,
+                                            noise_amplitude=amplitude_threshold + 0.02,
                                             frequency=target_freq
                                             )
                 r = kitchen_setup.send_goal(goal=None, goal_type=MoveGoal.PLAN_AND_EXECUTE)
@@ -2087,10 +2099,12 @@ class TestShaking(object):
         amplitude_threshold = kitchen_setup.get_god_map().get_data(identifier.amplitude_threshold)
         max_detectable_freq = int(1 / (2 * sample_period))
         min_wiggle_frequency = int(frequency_range * max_detectable_freq)
-        distance_between_frequencies = 5 if sample_period < 0.05 else 1
+        while np.fmod(min_wiggle_frequency, 5.0) != 0.0:
+            min_wiggle_frequency += 1
+        distance_between_frequencies = 5
 
-        for revolute_joint in [u'r_wrist_flex_joint', u'head_pan_joint']:  # max vel. of 1.0 and 1.0
-            for f in range(min_wiggle_frequency, max_detectable_freq + 1, distance_between_frequencies):  # todo: with 5, and 10 hertz
+        for revolute_joint in [ u'r_wrist_flex_joint', u'head_pan_joint']:  # max vel. of 1.0 and 0.5
+            for f in range(min_wiggle_frequency, max_detectable_freq, distance_between_frequencies):
                 target_freq = float(f)
 
                 if f == min_wiggle_frequency:
@@ -2103,10 +2117,16 @@ class TestShaking(object):
                 kitchen_setup.set_json_goal(u'ShakyJointPositionRevoluteOrPrismatic',
                                             joint_name=revolute_joint,
                                             goal=0.0,
-                                            noise_amplitude=amplitude_threshold - 0.1,
+                                            noise_amplitude=amplitude_threshold - 0.02,
                                             frequency=target_freq
                                             )
-                kitchen_setup.send_and_check_goal()
+                r = kitchen_setup.send_goal(goal=None, goal_type=MoveGoal.PLAN_AND_EXECUTE)
+                if any(map(lambda c: c == MoveResult.SHAKING, r.error_codes)):
+                    error_message = r.error_messages[0]
+                    freqs_str = re.findall("[0-9]+\.[0-9]+ hertz", error_message)
+                    assert all(map(lambda f_str: float(f_str[:-6]) != target_freq, freqs_str))
+                else:
+                    assert True
 
 
 class TestCollisionAvoidanceGoals(object):


### PR DESCRIPTION
Added shaking constraints for the evaluation of the shaking detector. Further, the shaking detector was changed for more stable detection of shaking frequencies. Therefore, the `amplitude_treshold` in the `pr2.config` was changed too. The tests were written in `test_integration_pr2.py`

Failed tests (also fail on current devel):
<details>
  <summary>show test_ease_dishwasher log!</summary>
  
```
/usr/bin/python2.7 /snap/pycharm-professional/242/plugins/python/helpers/pycharm/_jb_pytest_runner.py --target test_integration_pr2.py::TestCollisionAvoidanceGoals.test_ease_dishwasher
Testing started at 11:08 ...
Launching pytest with arguments test_integration_pr2.py::TestCollisionAvoidanceGoals::test_ease_dishwasher in /home/thomas/ros_ws/src/giskardpy/test

============================= test session starts ==============================
platform linux2 -- Python 2.7.17, pytest-3.3.2, py-1.5.2, pluggy-0.6.0 -- /usr/bin/python2.7
cachedir: ../.cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/home/thomas/ros_ws/src/giskardpy/test/.hypothesis/examples')
rootdir: /home/thomas/ros_ws/src/giskardpy, inifile:
plugins: hypothesis-4.34.0
collecting ... collected 1 item

test_integration_pr2.py::TestCollisionAvoidanceGoals::test_ease_dishwasher started roslaunch server http://thomas-MS-7C91:35391/

SUMMARY
========

PARAMETERS
 * /rosdistro: melodic
 * /rosversion: 1.14.10

NODES

ROS_MASTER_URI=http://localhost:11311
process[joint_trajectory_splitter-1]: started with pid [20836]
[INFO] [1622711313.619174]: [/tests]: --> added ground_plane to world
[INFO] [1622711313.623136]: [/tests]: --> added pybullet_hack to world
[INFO] [1622711314.098846]: [/tests]: --> added pr2 to world
[INFO] [1622711314.224616]: [/tests]: loaded self collision matrix tmp_data/collision_matrix//pr2/b0057f62f931d87bc6455fc9444aa08e
[INFO] [1622711314.230351]: [/tests]: waiting for action server '/whole_body_controller/follow_joint_trajectory' to appear
[INFO] [1622711314.230978]: [/tests]: successfully connected to action server
[INFO] [1622711314.237242]: [/tests]: Writing tmp_data/tree.dot/svg/png
[INFO] [1622711316.490153]: [/tests]: resetting giskard
[INFO] [1622711316.495849]: [/tests]: <-- removed object pybullet_hack from world
[INFO] [1622711316.496875]: [/tests]: <-- removed object ground_plane from world
[INFO] [1622711316.666234]: [/tests]: loaded self collision matrix tmp_data/collision_matrix//pr2/b0057f62f931d87bc6455fc9444aa08e
[INFO] [1622711316.670339]: [/tests]: --> added ground_plane to world
[INFO] [1622711316.674022]: [/tests]: --> added pybullet_hack to world
[INFO] [1622711317.803988]: [/tests]: parsing goal message
[INFO] [1622711317.804905]: [/tests]: adding constraint of type: 'JointPositionList'
[INFO] [1622711317.809506]: [/tests]: done parsing goal message
[INFO] [1622711318.491223]: [/tests]: constructing new controller with 17 soft constraints...
[INFO] [1622711318.492620]: [/tests]: computed Jacobian in 0.00019s
[INFO] [1622711318.494568]: [/tests]: compiled symbolic expressions in 0.00082s
[INFO] [1622711318.634460]: [/tests]: found loop, stopped planning.
[INFO] [1622711318.635245]: [/tests]: found goal trajectory with length 1.05s in 0.825065135956s
[INFO] [1622711322.365042]: [/tests]: --> added kitchen to world
FAILED [100%][INFO] [1622711324.099363]: [/tests]: parsing goal message
[INFO] [1622711324.100252]: [/tests]: adding constraint of type: 'GraspBar'
[INFO] [1622711324.103852]: [/tests]: adding constraint of type: 'AlignPlanes'
[INFO] [1622711324.105593]: [/tests]: done parsing goal message
[INFO] [1622711324.146420]: [/tests]: constructing new controller with 9 soft constraints...
[INFO] [1622711324.148185]: [/tests]: computed Jacobian in 0.00076s
[INFO] [1622711324.150019]: [/tests]: compiled symbolic expressions in 0.00090s
[INFO] [1622711324.987106]: [/tests]: found goal trajectory with length 5.9s in 0.880923986435s
[INFO] [1622711333.659719]: [/tests]: adding 39 external collision avoidance constraints
[INFO] [1622711333.725102]: [/tests]: adding 67 self collision avoidance constraints
[INFO] [1622711333.725852]: [/tests]: parsing goal message
[INFO] [1622711333.726412]: [/tests]: adding constraint of type: 'Open'
[INFO] [1622711333.739863]: [/tests]: done parsing goal message
[INFO] [1622711333.758618]: [/tests]: constructing new controller with 113 soft constraints...
[INFO] [1622711333.800199]: [/tests]: computed Jacobian in 0.03933s
[INFO] [1622711333.830416]: [/tests]: compiled symbolic expressions in 0.02503s
[INFO] [1622711335.861123]: [/tests]: found goal trajectory with length 4.8s in 2.12058901787s
[INFO] [1622711343.960255]: [/tests]: adding 39 external collision avoidance constraints
[INFO] [1622711344.009352]: [/tests]: adding 67 self collision avoidance constraints
[INFO] [1622711344.010152]: [/tests]: parsing goal message
[INFO] [1622711344.010716]: [/tests]: adding constraint of type: 'JointPositionList'
[INFO] [1622711344.013278]: [/tests]: done parsing goal message
[INFO] [1622711344.032712]: [/tests]: constructing new controller with 123 soft constraints...
[INFO] [1622711344.072499]: [/tests]: computed Jacobian in 0.03703s
[INFO] [1622711344.093519]: [/tests]: compiled symbolic expressions in 0.01683s
[INFO] [1622711344.760334]: [/tests]: found goal trajectory with length 1.7s in 0.746449947357s
[INFO] [1622711349.402687]: [/tests]: adding 39 external collision avoidance constraints
[INFO] [1622711349.455635]: [/tests]: adding 67 self collision avoidance constraints
[INFO] [1622711349.456455]: [/tests]: parsing goal message
[INFO] [1622711349.457082]: [/tests]: adding constraint of type: 'GraspBar'
[INFO] [1622711349.459605]: [/tests]: done parsing goal message
[INFO] [1622711349.477763]: [/tests]: constructing new controller with 112 soft constraints...
[INFO] [1622711349.517877]: [/tests]: computed Jacobian in 0.03765s
[INFO] [1622711349.538769]: [/tests]: compiled symbolic expressions in 0.01758s
Traceback (most recent call last):
  File "/home/thomas/ros_ws/src/giskardpy/src/giskardpy/plugin.py", line 158, in loop_over_plugins
    for node in plugin.tick():
  File "/opt/ros/melodic/lib/python2.7/dist-packages/py_trees/behaviour.py", line 249, in tick
    new_status = self.update()
  File "/home/thomas/ros_ws/src/giskardpy/src/giskardpy/plugin_interrupts.py", line 76, in update
    raise e
ShakingException: endless wiggling detected
shaking of joint: 'r_elbow_flex_joint' at 9.0 hertz: 0.615874686544 > 0.55
shaking of joint: 'r_wrist_flex_joint' at 9.0 hertz: 0.680364310598 > 0.55

test/test_integration_pr2.py:7684 (TestCollisionAvoidanceGoals.test_ease_dishwasher)
self = <test_integration_pr2.TestCollisionAvoidanceGoals object at 0x7f93d1261310>
kitchen_setup = <utils_for_tests.PR2 object at 0x7f93d12616d0>

    def test_ease_dishwasher(self, kitchen_setup):
        """
            :type kitchen_setup: PR2
            """
        # FIXME
        p = PoseStamped()
        p.header.frame_id = u'map'
        p.pose.orientation.w = 1
        p.pose.position.x = 0.5
        p.pose.position.y = 0.2
        kitchen_setup.teleport_base(p)
    
        hand = kitchen_setup.r_tip
    
        goal_angle = np.pi / 4
        handle_frame_id = u'iai_kitchen/sink_area_dish_washer_door_handle'
        handle_name = u'sink_area_dish_washer_door_handle'
        bar_axis = Vector3Stamped()
        bar_axis.header.frame_id = handle_frame_id
        bar_axis.vector.y = 1
    
        bar_center = PointStamped()
        bar_center.header.frame_id = handle_frame_id
    
        tip_grasp_axis = Vector3Stamped()
        tip_grasp_axis.header.frame_id = hand
        tip_grasp_axis.vector.z = 1
    
        kitchen_setup.set_json_goal(u'GraspBar',
                                    root_link=kitchen_setup.default_root,
                                    tip_link=hand,
                                    tip_grasp_axis=tip_grasp_axis,
                                    bar_center=bar_center,
                                    bar_axis=bar_axis,
                                    bar_length=.3)
        # kitchen_setup.allow_collision([], u'kitchen', [handle_name])
        kitchen_setup.allow_all_collisions()
    
        gripper_axis = Vector3Stamped()
        gripper_axis.header.frame_id = hand
        gripper_axis.vector.x = 1
    
        world_axis = Vector3Stamped()
        world_axis.header.frame_id = handle_frame_id
        world_axis.vector.x = -1
        kitchen_setup.align_planes(hand, gripper_axis, root_normal=world_axis)
        # kitchen_setup.allow_all_collisions()
    
        kitchen_setup.send_and_check_goal()
    
        kitchen_setup.set_json_goal(u'Open',
                                    tip_link=hand,
                                    object_name=u'kitchen',
                                    object_link_name=handle_name,
                                    goal_joint_state=goal_angle,
                                    # weight=100
                                    )
        # kitchen_setup.allow_all_collisions()
        kitchen_setup.send_and_check_goal()
        kitchen_setup.set_kitchen_js({u'sink_area_dish_washer_door_joint': goal_angle})
        # ----------------------------------------------------------------------------------------
        kitchen_setup.send_and_check_joint_goal(gaya_pose)
    
        tray_handle_frame_id = u'iai_kitchen/sink_area_dish_washer_tray_handle_front_side'
        tray_handle_name = u'sink_area_dish_washer_tray_handle_front_side'
        bar_axis = Vector3Stamped()
        bar_axis.header.frame_id = tray_handle_frame_id
        bar_axis.vector.y = 1
        bar_axis.vector.z = -0.1
    
        bar_center = PointStamped()
        bar_center.header.frame_id = tray_handle_frame_id
    
        tip_grasp_axis = Vector3Stamped()
        tip_grasp_axis.header.frame_id = hand
        tip_grasp_axis.vector.z = 1
    
        kitchen_setup.set_json_goal(u'GraspBar',
                                    root_link=kitchen_setup.default_root,
                                    tip_link=hand,
                                    tip_grasp_axis=tip_grasp_axis,
                                    bar_center=bar_center,
                                    bar_axis=bar_axis,
                                    bar_length=.3)
        # kitchen_setup.allow_collision([], u'kitchen', [handle_name])
>       kitchen_setup.send_and_check_goal()

test_integration_pr2.py:7770: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <utils_for_tests.PR2 object at 0x7f93d12616d0>
expected_error_codes = None, goal_type = 5, goal = None

    def send_and_check_goal(self, expected_error_codes=None, goal_type=MoveGoal.PLAN_AND_EXECUTE, goal=None):
        r = self.send_goal(goal=goal, goal_type=goal_type)
        for i in range(len(r.error_codes)):
            error_code = r.error_codes[i]
            error_message = r.error_messages[i]
            if expected_error_codes is None:
                expected_error_code = MoveResult.SUCCESS
            else:
                expected_error_code = expected_error_codes[i]
            assert error_code == expected_error_code, \
                u'in goal {}; got: {}, expected: {} | error_massage: {}'.format(i, move_result_error_code(error_code),
                                                                                move_result_error_code(
                                                                                    expected_error_code),
>                                                                               error_message)
E           AssertionError: in goal 0; got: SHAKING, expected: SUCCESS | error_massage: endless wiggling detected
E           shaking of joint: 'r_elbow_flex_joint' at 9.0 hertz: 0.615874686544 > 0.55
E           shaking of joint: 'r_wrist_flex_joint' at 9.0 hertz: 0.680364310598 > 0.55

utils_for_tests.py:546: AssertionError
[INFO] [1622711354.699185]: [/tests]: total time spend giskarding: 14.9552946091
[INFO] [1622711354.700618]: [/tests]: total time spend moving: 19.309330225
[INFO] [1622711354.703894]: [/tests]: stopping plugins
[INFO] [1622711354.907637]: [/tests]: shutdown ros
[joint_trajectory_splitter-1] process has died without exit code [pid 20836, cmd /home/thomas/ros_ws/src/giskardpy/scripts/joint_trajectory_splitter.py __name:=joint_trajectory_splitter __log:=/home/thomas/.ros/log/640cf914-c443-11eb-902c-00e18c544462/joint_trajectory_splitter-1.log].
log file: /home/thomas/.ros/log/640cf914-c443-11eb-902c-00e18c544462/joint_trajectory_splitter-1*.log
[INFO] [1622711355.035915]: [/tests]: deleting tmp test folder




=================================== FAILURES ===================================
_______________ TestCollisionAvoidanceGoals.test_ease_dishwasher _______________

self = <test_integration_pr2.TestCollisionAvoidanceGoals object at 0x7f93d1261310>
kitchen_setup = <utils_for_tests.PR2 object at 0x7f93d12616d0>

    def test_ease_dishwasher(self, kitchen_setup):
        """
            :type kitchen_setup: PR2
            """
        # FIXME
        p = PoseStamped()
        p.header.frame_id = u'map'
        p.pose.orientation.w = 1
        p.pose.position.x = 0.5
        p.pose.position.y = 0.2
        kitchen_setup.teleport_base(p)
    
        hand = kitchen_setup.r_tip
    
        goal_angle = np.pi / 4
        handle_frame_id = u'iai_kitchen/sink_area_dish_washer_door_handle'
        handle_name = u'sink_area_dish_washer_door_handle'
        bar_axis = Vector3Stamped()
        bar_axis.header.frame_id = handle_frame_id
        bar_axis.vector.y = 1
    
        bar_center = PointStamped()
        bar_center.header.frame_id = handle_frame_id
    
        tip_grasp_axis = Vector3Stamped()
        tip_grasp_axis.header.frame_id = hand
        tip_grasp_axis.vector.z = 1
    
        kitchen_setup.set_json_goal(u'GraspBar',
                                    root_link=kitchen_setup.default_root,
                                    tip_link=hand,
                                    tip_grasp_axis=tip_grasp_axis,
                                    bar_center=bar_center,
                                    bar_axis=bar_axis,
                                    bar_length=.3)
        # kitchen_setup.allow_collision([], u'kitchen', [handle_name])
        kitchen_setup.allow_all_collisions()
    
        gripper_axis = Vector3Stamped()
        gripper_axis.header.frame_id = hand
        gripper_axis.vector.x = 1
    
        world_axis = Vector3Stamped()
        world_axis.header.frame_id = handle_frame_id
        world_axis.vector.x = -1
        kitchen_setup.align_planes(hand, gripper_axis, root_normal=world_axis)
        # kitchen_setup.allow_all_collisions()
    
        kitchen_setup.send_and_check_goal()
    
        kitchen_setup.set_json_goal(u'Open',
                                    tip_link=hand,
                                    object_name=u'kitchen',
                                    object_link_name=handle_name,
                                    goal_joint_state=goal_angle,
                                    # weight=100
                                    )
        # kitchen_setup.allow_all_collisions()
        kitchen_setup.send_and_check_goal()
        kitchen_setup.set_kitchen_js({u'sink_area_dish_washer_door_joint': goal_angle})
        # ----------------------------------------------------------------------------------------
        kitchen_setup.send_and_check_joint_goal(gaya_pose)
    
        tray_handle_frame_id = u'iai_kitchen/sink_area_dish_washer_tray_handle_front_side'
        tray_handle_name = u'sink_area_dish_washer_tray_handle_front_side'
        bar_axis = Vector3Stamped()
        bar_axis.header.frame_id = tray_handle_frame_id
        bar_axis.vector.y = 1
        bar_axis.vector.z = -0.1
    
        bar_center = PointStamped()
        bar_center.header.frame_id = tray_handle_frame_id
    
        tip_grasp_axis = Vector3Stamped()
        tip_grasp_axis.header.frame_id = hand
        tip_grasp_axis.vector.z = 1
    
        kitchen_setup.set_json_goal(u'GraspBar',
                                    root_link=kitchen_setup.default_root,
                                    tip_link=hand,
                                    tip_grasp_axis=tip_grasp_axis,
                                    bar_center=bar_center,
                                    bar_axis=bar_axis,
                                    bar_length=.3)
        # kitchen_setup.allow_collision([], u'kitchen', [handle_name])
>       kitchen_setup.send_and_check_goal()

test_integration_pr2.py:7770: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <utils_for_tests.PR2 object at 0x7f93d12616d0>
expected_error_codes = None, goal_type = 5, goal = None

    def send_and_check_goal(self, expected_error_codes=None, goal_type=MoveGoal.PLAN_AND_EXECUTE, goal=None):
        r = self.send_goal(goal=goal, goal_type=goal_type)
        for i in range(len(r.error_codes)):
            error_code = r.error_codes[i]
            error_message = r.error_messages[i]
            if expected_error_codes is None:
                expected_error_code = MoveResult.SUCCESS
            else:
                expected_error_code = expected_error_codes[i]
            assert error_code == expected_error_code, \
                u'in goal {}; got: {}, expected: {} | error_massage: {}'.format(i, move_result_error_code(error_code),
                                                                                move_result_error_code(
                                                                                    expected_error_code),
>                                                                               error_message)
E           AssertionError: in goal 0; got: SHAKING, expected: SUCCESS | error_massage: endless wiggling detected
E           shaking of joint: 'r_elbow_flex_joint' at 9.0 hertz: 0.615874686544 > 0.55
E           shaking of joint: 'r_wrist_flex_joint' at 9.0 hertz: 0.680364310598 > 0.55

utils_for_tests.py:546: AssertionError
---------------------------- Captured stdout setup -----------------------------
started roslaunch server http://thomas-MS-7C91:35391/

SUMMARY
========

PARAMETERS
 * /rosdistro: melodic
 * /rosversion: 1.14.10

NODES

ROS_MASTER_URI=http://localhost:11311
process[joint_trajectory_splitter-1]: started with pid [20836]
[INFO] [1622711313.619174]: [/tests]: --> added ground_plane to world
[INFO] [1622711313.623136]: [/tests]: --> added pybullet_hack to world
[INFO] [1622711314.098846]: [/tests]: --> added pr2 to world
[INFO] [1622711314.224616]: [/tests]: loaded self collision matrix tmp_data/collision_matrix//pr2/b0057f62f931d87bc6455fc9444aa08e
[INFO] [1622711314.230351]: [/tests]: waiting for action server '/whole_body_controller/follow_joint_trajectory' to appear
[INFO] [1622711314.230978]: [/tests]: successfully connected to action server
[INFO] [1622711314.237242]: [/tests]: Writing tmp_data/tree.dot/svg/png
[INFO] [1622711316.490153]: [/tests]: resetting giskard
[INFO] [1622711316.495849]: [/tests]: <-- removed object pybullet_hack from world
[INFO] [1622711316.496875]: [/tests]: <-- removed object ground_plane from world
[INFO] [1622711316.666234]: [/tests]: loaded self collision matrix tmp_data/collision_matrix//pr2/b0057f62f931d87bc6455fc9444aa08e
[INFO] [1622711316.670339]: [/tests]: --> added ground_plane to world
[INFO] [1622711316.674022]: [/tests]: --> added pybullet_hack to world
[INFO] [1622711317.803988]: [/tests]: parsing goal message
[INFO] [1622711317.804905]: [/tests]: adding constraint of type: 'JointPositionList'
[INFO] [1622711317.809506]: [/tests]: done parsing goal message
[INFO] [1622711318.491223]: [/tests]: constructing new controller with 17 soft constraints...
[INFO] [1622711318.492620]: [/tests]: computed Jacobian in 0.00019s
[INFO] [1622711318.494568]: [/tests]: compiled symbolic expressions in 0.00082s
[INFO] [1622711318.634460]: [/tests]: found loop, stopped planning.
[INFO] [1622711318.635245]: [/tests]: found goal trajectory with length 1.05s in 0.825065135956s
[INFO] [1622711322.365042]: [/tests]: --> added kitchen to world
------------------------------ Captured log setup ------------------------------
logging.py                  49 INFO     [/unnamed]: deleting tmp test folder
logging.py                  49 INFO     [/unnamed]: init ros
----------------------------- Captured stdout call -----------------------------
[INFO] [1622711324.099363]: [/tests]: parsing goal message
[INFO] [1622711324.100252]: [/tests]: adding constraint of type: 'GraspBar'
[INFO] [1622711324.103852]: [/tests]: adding constraint of type: 'AlignPlanes'
[INFO] [1622711324.105593]: [/tests]: done parsing goal message
[INFO] [1622711324.146420]: [/tests]: constructing new controller with 9 soft constraints...
[INFO] [1622711324.148185]: [/tests]: computed Jacobian in 0.00076s
[INFO] [1622711324.150019]: [/tests]: compiled symbolic expressions in 0.00090s
[INFO] [1622711324.987106]: [/tests]: found goal trajectory with length 5.9s in 0.880923986435s
[INFO] [1622711333.659719]: [/tests]: adding 39 external collision avoidance constraints
[INFO] [1622711333.725102]: [/tests]: adding 67 self collision avoidance constraints
[INFO] [1622711333.725852]: [/tests]: parsing goal message
[INFO] [1622711333.726412]: [/tests]: adding constraint of type: 'Open'
[INFO] [1622711333.739863]: [/tests]: done parsing goal message
[INFO] [1622711333.758618]: [/tests]: constructing new controller with 113 soft constraints...
[INFO] [1622711333.800199]: [/tests]: computed Jacobian in 0.03933s
[INFO] [1622711333.830416]: [/tests]: compiled symbolic expressions in 0.02503s
[INFO] [1622711335.861123]: [/tests]: found goal trajectory with length 4.8s in 2.12058901787s
[INFO] [1622711343.960255]: [/tests]: adding 39 external collision avoidance constraints
[INFO] [1622711344.009352]: [/tests]: adding 67 self collision avoidance constraints
[INFO] [1622711344.010152]: [/tests]: parsing goal message
[INFO] [1622711344.010716]: [/tests]: adding constraint of type: 'JointPositionList'
[INFO] [1622711344.013278]: [/tests]: done parsing goal message
[INFO] [1622711344.032712]: [/tests]: constructing new controller with 123 soft constraints...
[INFO] [1622711344.072499]: [/tests]: computed Jacobian in 0.03703s
[INFO] [1622711344.093519]: [/tests]: compiled symbolic expressions in 0.01683s
[INFO] [1622711344.760334]: [/tests]: found goal trajectory with length 1.7s in 0.746449947357s
[INFO] [1622711349.402687]: [/tests]: adding 39 external collision avoidance constraints
[INFO] [1622711349.455635]: [/tests]: adding 67 self collision avoidance constraints
[INFO] [1622711349.456455]: [/tests]: parsing goal message
[INFO] [1622711349.457082]: [/tests]: adding constraint of type: 'GraspBar'
[INFO] [1622711349.459605]: [/tests]: done parsing goal message
[INFO] [1622711349.477763]: [/tests]: constructing new controller with 112 soft constraints...
[INFO] [1622711349.517877]: [/tests]: computed Jacobian in 0.03765s
[INFO] [1622711349.538769]: [/tests]: compiled symbolic expressions in 0.01758s
----------------------------- Captured stderr call -----------------------------
Traceback (most recent call last):
  File "/home/thomas/ros_ws/src/giskardpy/src/giskardpy/plugin.py", line 158, in loop_over_plugins
    for node in plugin.tick():
  File "/opt/ros/melodic/lib/python2.7/dist-packages/py_trees/behaviour.py", line 249, in tick
    new_status = self.update()
  File "/home/thomas/ros_ws/src/giskardpy/src/giskardpy/plugin_interrupts.py", line 76, in update
    raise e
ShakingException: endless wiggling detected
shaking of joint: 'r_elbow_flex_joint' at 9.0 hertz: 0.615874686544 > 0.55
shaking of joint: 'r_wrist_flex_joint' at 9.0 hertz: 0.680364310598 > 0.55
------------------------------ Captured log call -------------------------------
tcpros_base.py             640 DEBUG    [/base_simulator/set_joint_states]: writing header
logging.py                  49 INFO     [/tests]: parsing goal message
logging.py                  49 INFO     [/tests]: adding constraint of type: 'GraspBar'
logging.py                  49 INFO     [/tests]: adding constraint of type: 'AlignPlanes'
logging.py                  49 INFO     [/tests]: done parsing goal message
logging.py                  49 INFO     [/tests]: constructing new controller with 9 soft constraints...
logging.py                  49 INFO     [/tests]: computed Jacobian in 0.00076s
logging.py                  49 INFO     [/tests]: compiled symbolic expressions in 0.00090s
logging.py                  49 INFO     [/tests]: found goal trajectory with length 5.9s in 0.880923986435s
logging.py                  49 INFO     [/tests]: adding 39 external collision avoidance constraints
logging.py                  49 INFO     [/tests]: adding 67 self collision avoidance constraints
logging.py                  49 INFO     [/tests]: parsing goal message
logging.py                  49 INFO     [/tests]: adding constraint of type: 'Open'
logging.py                  49 INFO     [/tests]: done parsing goal message
logging.py                  49 INFO     [/tests]: constructing new controller with 113 soft constraints...
logging.py                  49 INFO     [/tests]: computed Jacobian in 0.03933s
logging.py                  49 INFO     [/tests]: compiled symbolic expressions in 0.02503s
logging.py                  49 INFO     [/tests]: found goal trajectory with length 4.8s in 2.12058901787s
logging.py                  49 INFO     [/tests]: adding 39 external collision avoidance constraints
logging.py                  49 INFO     [/tests]: adding 67 self collision avoidance constraints
logging.py                  49 INFO     [/tests]: parsing goal message
logging.py                  49 INFO     [/tests]: adding constraint of type: 'JointPositionList'
logging.py                  49 INFO     [/tests]: done parsing goal message
logging.py                  49 INFO     [/tests]: constructing new controller with 123 soft constraints...
logging.py                  49 INFO     [/tests]: computed Jacobian in 0.03703s
logging.py                  49 INFO     [/tests]: compiled symbolic expressions in 0.01683s
logging.py                  49 INFO     [/tests]: found goal trajectory with length 1.7s in 0.746449947357s
logging.py                  49 INFO     [/tests]: adding 39 external collision avoidance constraints
logging.py                  49 INFO     [/tests]: adding 67 self collision avoidance constraints
logging.py                  49 INFO     [/tests]: parsing goal message
logging.py                  49 INFO     [/tests]: adding constraint of type: 'GraspBar'
logging.py                  49 INFO     [/tests]: done parsing goal message
logging.py                  49 INFO     [/tests]: constructing new controller with 112 soft constraints...
logging.py                  49 INFO     [/tests]: computed Jacobian in 0.03765s
logging.py                  49 INFO     [/tests]: compiled symbolic expressions in 0.01758s
--------------------------- Captured stdout teardown ---------------------------
[INFO] [1622711354.699185]: [/tests]: total time spend giskarding: 14.9552946091
[INFO] [1622711354.700618]: [/tests]: total time spend moving: 19.309330225
[INFO] [1622711354.703894]: [/tests]: stopping plugins
[INFO] [1622711354.907637]: [/tests]: shutdown ros
[joint_trajectory_splitter-1] process has died without exit code [pid 20836, cmd /home/thomas/ros_ws/src/giskardpy/scripts/joint_trajectory_splitter.py __name:=joint_trajectory_splitter __log:=/home/thomas/.ros/log/640cf914-c443-11eb-902c-00e18c544462/joint_trajectory_splitter-1.log].
log file: /home/thomas/.ros/log/640cf914-c443-11eb-902c-00e18c544462/joint_trajectory_splitter-1*.log
[INFO] [1622711355.035915]: [/tests]: deleting tmp test folder
---------------------------- Captured log teardown -----------------------------
logging.py                  49 INFO     [/tests]: total time spend giskarding: 14.9552946091
logging.py                  49 INFO     [/tests]: total time spend moving: 19.309330225
logging.py                  49 INFO     [/tests]: stopping plugins
nodeprocess.py             503 DEBUG    process[joint_trajectory_splitter-1].stop() starting
nodeprocess.py             402 INFO     process[joint_trajectory_splitter-1]: killing os process with pid[20836] pgid[20836]
nodeprocess.py             406 INFO     [joint_trajectory_splitter-1] sending SIGINT to pgid [20836]
nodeprocess.py             408 INFO     [joint_trajectory_splitter-1] sent SIGINT to pgid [20836]
tcpros_base.py             640 DEBUG    [/whole_body_controller/follow_joint_trajectory/result]: writing header
core.py                    143 ERROR    Unable to initiate TCP/IP socket to thomas-MS-7C91:36099 (http://thomas-MS-7C91:44133/): Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 562, in connect
    self.read_header()
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 657, in read_header
    self._validate_header(read_ros_handshake_header(sock, self.read_buff, self.protocol.buff_size))
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 600, in _validate_header
    raise TransportInitError("remote error reported: %s"%header['error'])
TransportInitError: remote error reported: node shutting down

tcpros_base.py             640 DEBUG    [/whole_body_controller/follow_joint_trajectory/status]: writing header
core.py                    143 ERROR    Unable to initiate TCP/IP socket to thomas-MS-7C91:36099 (http://thomas-MS-7C91:44133/): Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 562, in connect
    self.read_header()
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 657, in read_header
    self._validate_header(read_ros_handshake_header(sock, self.read_buff, self.protocol.buff_size))
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 600, in _validate_header
    raise TransportInitError("remote error reported: %s"%header['error'])
TransportInitError: remote error reported: node shutting down

tcpros_base.py             640 DEBUG    [/whole_body_controller/follow_joint_trajectory/feedback]: writing header
core.py                    143 ERROR    Unable to initiate TCP/IP socket to thomas-MS-7C91:36099 (http://thomas-MS-7C91:44133/): Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 562, in connect
    self.read_header()
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 657, in read_header
    self._validate_header(read_ros_handshake_header(sock, self.read_buff, self.protocol.buff_size))
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 600, in _validate_header
    raise TransportInitError("remote error reported: %s"%header['error'])
TransportInitError: remote error reported: node shutting down

masterslave.py             115 DEBUG    publisherUpdate('/master', '/whole_body_controller/follow_joint_trajectory/result', [])
masterslave.py             147 DEBUG    publisherUpdate('/master', '/whole_body_controller/follow_joint_trajectory/result', []) returns (1, '', 0)
masterslave.py             115 DEBUG    publisherUpdate('/master', '/whole_body_controller/follow_joint_trajectory/status', [])
masterslave.py             147 DEBUG    publisherUpdate('/master', '/whole_body_controller/follow_joint_trajectory/status', []) returns (1, '', 0)
masterslave.py             115 DEBUG    publisherUpdate('/master', '/whole_body_controller/follow_joint_trajectory/feedback', [])
masterslave.py             147 DEBUG    publisherUpdate('/master', '/whole_body_controller/follow_joint_trajectory/feedback', []) returns (1, '', 0)
nodeprocess.py             444 INFO     process[joint_trajectory_splitter-1]: SIGINT killed with return value 0
logging.py                  49 INFO     [/tests]: shutdown ros
core.py                    560 INFO     signal_shutdown [die]
registration.py            336 DEBUG    registration cleanup starting
registration.py            365 DEBUG    unregisterSubscriber [/kitchen/joint_states]
registration.py            365 DEBUG    unregisterSubscriber [/tests/command/feedback]
registration.py            365 DEBUG    unregisterSubscriber [/whole_body_controller/follow_joint_trajectory/result]
registration.py            365 DEBUG    unregisterSubscriber [/joint_states]
registration.py            365 DEBUG    unregisterSubscriber [/tests/command/result]
registration.py            365 DEBUG    unregisterSubscriber [/tf]
registration.py            365 DEBUG    unregisterSubscriber [/tf_static]
registration.py            365 DEBUG    unregisterSubscriber [/whole_body_controller/follow_joint_trajectory/goal]
registration.py            365 DEBUG    unregisterSubscriber [/whole_body_controller/follow_joint_trajectory/status]
registration.py            365 DEBUG    unregisterSubscriber [/tests/command/goal]
registration.py            365 DEBUG    unregisterSubscriber [/tests/command/cancel]
registration.py            365 DEBUG    unregisterSubscriber [/whole_body_controller/follow_joint_trajectory/feedback]
registration.py            365 DEBUG    unregisterSubscriber [/tests/command/status]
registration.py            368 DEBUG    unregisterPublisher [/tests/visualization_marker_array]
registration.py            368 DEBUG    unregisterPublisher [/whole_body_controller/follow_joint_trajectory/goal]
registration.py            368 DEBUG    unregisterPublisher [/tests/command/feedback]
registration.py            368 DEBUG    unregisterPublisher [/visualization_marker_array]
registration.py            368 DEBUG    unregisterPublisher [/tests/introspection/publishers]
registration.py            368 DEBUG    unregisterPublisher [/tests/blackboard]
registration.py            368 DEBUG    unregisterPublisher [/rosout]
registration.py            368 DEBUG    unregisterPublisher [/tests/command/result]
registration.py            368 DEBUG    unregisterPublisher [/tf]
registration.py            368 DEBUG    unregisterPublisher [/tests/tip]
registration.py            368 DEBUG    unregisterPublisher [/move_base_simple/goal]
registration.py            368 DEBUG    unregisterPublisher [/tests/ascii/tree]
registration.py            368 DEBUG    unregisterPublisher [/tests/command/goal]
registration.py            368 DEBUG    unregisterPublisher [/tests/log/tree]
registration.py            368 DEBUG    unregisterPublisher [/tests/command/cancel]
registration.py            368 DEBUG    unregisterPublisher [/tests/ascii/snapshot]
registration.py            368 DEBUG    unregisterPublisher [/tests/command/status]
registration.py            368 DEBUG    unregisterPublisher [/kitchen/cram_joint_states]
registration.py            368 DEBUG    unregisterPublisher [/tests/dot/tree]
registration.py            368 DEBUG    unregisterPublisher [/whole_body_controller/follow_joint_trajectory/cancel]
registration.py            373 DEBUG    unregisterService [/tests/get_blackboard_variables]
registration.py            373 DEBUG    unregisterService [/tests/get_attached_objects]
registration.py            373 DEBUG    unregisterService [/tests/set_logger_level]
registration.py            373 DEBUG    unregisterService [/tests/dump_state]
registration.py            373 DEBUG    unregisterService [/tests/get_object_names]
registration.py            373 DEBUG    unregisterService [/tests/update_rviz_markers]
registration.py            373 DEBUG    unregisterService [/tests/close_blackboard_watcher]
registration.py            373 DEBUG    unregisterService [/tests/update_world]
registration.py            373 DEBUG    unregisterService [/tests/open_blackboard_watcher]
registration.py            373 DEBUG    unregisterService [/tests/get_object_info]
registration.py            373 DEBUG    unregisterService [/tests/get_loggers]
registration.py            373 DEBUG    unregisterService [/tests/render]
registration.py            373 DEBUG    unregisterService [/tests/tf2_frames]
registration.py            385 DEBUG    registration cleanup: master calls complete
core.py                    140 INFO     topic[/tests/visualization_marker_array] removing connection to /rviz_1622710689079853762
core.py                    140 INFO     topic[/whole_body_controller/follow_joint_trajectory/goal] removing connection to /tests
tcpros_base.py             640 DEBUG    [/whole_body_controller/follow_joint_trajectory/goal]: writing header
core.py                    140 INFO     topic[/whole_body_controller/follow_joint_trajectory/goal] removing connection to /joint_trajectory_splitter
core.py                    143 ERROR    Unable to initiate TCP/IP socket to thomas-MS-7C91:44455 (http://thomas-MS-7C91:42969/): Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 562, in connect
    self.read_header()
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 657, in read_header
    self._validate_header(read_ros_handshake_header(sock, self.read_buff, self.protocol.buff_size))
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 600, in _validate_header
    raise TransportInitError("remote error reported: %s"%header['error'])
TransportInitError: remote error reported: node shutting down

core.py                    140 INFO     topic[/tests/command/feedback] removing connection to /tests
tcpros_base.py             640 DEBUG    [/tests/command/feedback]: writing header
core.py                    140 INFO     topic[/rosout] removing connection to /rosout
core.py                    140 INFO     topic[/tests/command/result] removing connection to /tests
tcpros_base.py             640 DEBUG    [/tests/command/result]: writing header
core.py                    143 ERROR    Unable to initiate TCP/IP socket to thomas-MS-7C91:44455 (http://thomas-MS-7C91:42969/): Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 562, in connect
    self.read_header()
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 657, in read_header
    self._validate_header(read_ros_handshake_header(sock, self.read_buff, self.protocol.buff_size))
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 600, in _validate_header
    raise TransportInitError("remote error reported: %s"%header['error'])
TransportInitError: remote error reported: node shutting down

core.py                    140 INFO     topic[/tf] removing connection to /base_controller
core.py                    140 INFO     topic[/tf] removing connection to /tests
core.py                    143 ERROR    Unable to initiate TCP/IP socket to thomas-MS-7C91:44455 (http://thomas-MS-7C91:42969/): Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 562, in connect
    self.read_header()
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 657, in read_header
    self._validate_header(read_ros_handshake_header(sock, self.read_buff, self.protocol.buff_size))
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 600, in _validate_header
    raise TransportInitError("remote error reported: %s"%header['error'])
TransportInitError: remote error reported: node shutting down

tcpros_base.py             640 DEBUG    [/tf]: writing header
core.py                    140 INFO     topic[/tf] removing connection to /tf2_buffer_server
core.py                    140 INFO     topic[/tf] removing connection to /rviz_1622710689079853762
core.py                    140 INFO     topic[/tests/command/goal] removing connection to /tests
core.py                    143 ERROR    Unable to initiate TCP/IP socket to thomas-MS-7C91:44455 (http://thomas-MS-7C91:42969/): Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 562, in connect
    self.read_header()
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 657, in read_header
    self._validate_header(read_ros_handshake_header(sock, self.read_buff, self.protocol.buff_size))
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 600, in _validate_header
    raise TransportInitError("remote error reported: %s"%header['error'])
TransportInitError: remote error reported: node shutting down

tcpros_base.py             640 DEBUG    [/tests/command/goal]: writing header
core.py                    140 INFO     topic[/tests/command/cancel] removing connection to /tests
tcpros_base.py             640 DEBUG    [/tests/command/cancel]: writing header
core.py                    140 INFO     topic[/tests/command/status] removing connection to /tests
tcpros_base.py             640 DEBUG    [/tests/command/status]: writing header
core.py                    140 INFO     topic[/kitchen/cram_joint_states] removing connection to /kitchen_joint_state_publisher
core.py                    143 ERROR    Unable to initiate TCP/IP socket to thomas-MS-7C91:44455 (http://thomas-MS-7C91:42969/): Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 562, in connect
    self.read_header()
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 657, in read_header
    self._validate_header(read_ros_handshake_header(sock, self.read_buff, self.protocol.buff_size))
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 600, in _validate_header
    raise TransportInitError("remote error reported: %s"%header['error'])
TransportInitError: remote error reported: node shutting down

core.py                    143 ERROR    Unable to initiate TCP/IP socket to thomas-MS-7C91:44455 (http://thomas-MS-7C91:42969/): Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 562, in connect
    self.read_header()
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 657, in read_header
    self._validate_header(read_ros_handshake_header(sock, self.read_buff, self.protocol.buff_size))
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 600, in _validate_header
    raise TransportInitError("remote error reported: %s"%header['error'])
TransportInitError: remote error reported: node shutting down

core.py                    140 INFO     topic[/whole_body_controller/follow_joint_trajectory/cancel] removing connection to /joint_trajectory_splitter
core.py                    143 ERROR    Unable to initiate TCP/IP socket to thomas-MS-7C91:44455 (http://thomas-MS-7C91:42969/): Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 562, in connect
    self.read_header()
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 657, in read_header
    self._validate_header(read_ros_handshake_header(sock, self.read_buff, self.protocol.buff_size))
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 600, in _validate_header
    raise TransportInitError("remote error reported: %s"%header['error'])
TransportInitError: remote error reported: node shutting down

core.py                    140 INFO     topic[/kitchen/joint_states] removing connection to http://thomas-MS-7C91:45379/
core.py                    143 ERROR    Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 737, in receive_once
    self.stat_bytes += recv_buff(sock, b, p.buff_size)
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 104, in recv_buff
    d = sock.recv(buff_size)
error: [Errno 104] Connection reset by peer

core.py                    140 INFO     topic[/tests/command/feedback] removing connection to http://thomas-MS-7C91:42969/
core.py                    137 DEBUG    receive_loop[/kitchen/joint_states]: done condition met, exited loop
core.py                    140 INFO     topic[/whole_body_controller/follow_joint_trajectory/result] removing connection to http://thomas-MS-7C91:44133/
core.py                    140 INFO     topic[/joint_states] removing connection to http://thomas-MS-7C91:46591/
core.py                    143 ERROR    Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 737, in receive_once
    self.stat_bytes += recv_buff(sock, b, p.buff_size)
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 104, in recv_buff
    d = sock.recv(buff_size)
error: [Errno 104] Connection reset by peer

core.py                    140 INFO     topic[/tests/command/result] removing connection to http://thomas-MS-7C91:42969/
core.py                    137 DEBUG    receive_loop[/joint_states]: done condition met, exited loop
core.py                    140 INFO     topic[/tf] removing connection to http://thomas-MS-7C91:39257/
core.py                    137 DEBUG    receive_loop[/tf]: done condition met, exited loop
core.py                    140 INFO     topic[/tf] removing connection to http://thomas-MS-7C91:33195/
core.py                    146 WARNING  Unknown error initiating TCP/IP socket to thomas-MS-7C91:33625 (http://thomas-MS-7C91:33195/): Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 562, in connect
    self.read_header()
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 657, in read_header
    self._validate_header(read_ros_handshake_header(sock, self.read_buff, self.protocol.buff_size))
AttributeError: 'NoneType' object has no attribute 'buff_size'

topics.py                  329 ERROR    Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/topics.py", line 326, in close
    c.close()
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 846, in close
    self.socket.close()
AttributeError: 'NoneType' object has no attribute 'close'

core.py                    140 INFO     topic[/tf] removing connection to http://thomas-MS-7C91:40133/
core.py                    137 DEBUG    receive_loop[/tf]: done condition met, exited loop
core.py                    137 DEBUG    receive_loop[/tf]: done condition met, exited loop
core.py                    140 INFO     topic[/tf] removing connection to http://thomas-MS-7C91:40155/
core.py                    140 INFO     topic[/tf] removing connection to http://thomas-MS-7C91:42969/
core.py                    140 INFO     topic[/tf_static] removing connection to http://thomas-MS-7C91:33195/
core.py                    137 DEBUG    receive_loop[/tf_static]: done condition met, exited loop
core.py                    140 INFO     topic[/tf_static] removing connection to http://thomas-MS-7C91:40133/
topics.py                  329 ERROR    Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/topics.py", line 326, in close
    c.close()
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 846, in close
    self.socket.close()
AttributeError: 'NoneType' object has no attribute 'close'

core.py                    146 WARNING  Unknown error initiating TCP/IP socket to thomas-MS-7C91:48941 (http://thomas-MS-7C91:40133/): Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 562, in connect
    self.read_header()
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 657, in read_header
    self._validate_header(read_ros_handshake_header(sock, self.read_buff, self.protocol.buff_size))
AttributeError: 'NoneType' object has no attribute 'buff_size'

core.py                    140 INFO     topic[/whole_body_controller/follow_joint_trajectory/goal] removing connection to http://thomas-MS-7C91:42969/
core.py                    140 INFO     topic[/whole_body_controller/follow_joint_trajectory/status] removing connection to http://thomas-MS-7C91:44133/
core.py                    140 INFO     topic[/tests/command/goal] removing connection to http://thomas-MS-7C91:42969/
core.py                    140 INFO     topic[/tests/command/cancel] removing connection to http://thomas-MS-7C91:42969/
core.py                    140 INFO     topic[/whole_body_controller/follow_joint_trajectory/feedback] removing connection to http://thomas-MS-7C91:44133/
core.py                    140 INFO     topic[/tests/command/status] removing connection to http://thomas-MS-7C91:42969/
masterslave.py             342 INFO     die
pmon.py                    564 DEBUG    Process[joint_trajectory_splitter-1] has died, respawn=False, required=False, exit_code=None
pmon.py                    380 INFO     ProcessMonitor.unregister[joint_trajectory_splitter-1] starting
pmon.py                    383 INFO     ProcessMonitor.unregister[joint_trajectory_splitter-1] complete
nodeprocess.py             503 DEBUG    process[joint_trajectory_splitter-1].stop() starting
nodeprocess.py             505 DEBUG    process[%s].stop(): popen is None, nothing to kill
logging.py                  49 INFO     [/tests]: deleting tmp test folder
=============================== warnings summary ===============================
test/test_integration_pr2.py::TestCollisionAvoidanceGoals::()::test_ease_dishwasher
  /home/thomas/ros_ws/src/giskardpy/test/utils_for_tests.py:229: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
    config = yaml.load(f)

-- Docs: http://doc.pytest.org/en/latest/warnings.html
==================== 1 failed, 1 warnings in 48.33 seconds =====================

Process finished with exit code 1

```

</details>

<details>
  <summary>show test_ease_cereal log!</summary>

```
/usr/bin/python2.7 /snap/pycharm-professional/242/plugins/python/helpers/pycharm/_jb_pytest_runner.py --target test_integration_pr2.py::TestCollisionAvoidanceGoals.test_ease_cereal
Testing started at 11:10 ...
Launching pytest with arguments test_integration_pr2.py::TestCollisionAvoidanceGoals::test_ease_cereal in /home/thomas/ros_ws/src/giskardpy/test

============================= test session starts ==============================
platform linux2 -- Python 2.7.17, pytest-3.3.2, py-1.5.2, pluggy-0.6.0 -- /usr/bin/python2.7
cachedir: ../.cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/home/thomas/ros_ws/src/giskardpy/test/.hypothesis/examples')
rootdir: /home/thomas/ros_ws/src/giskardpy, inifile:
plugins: hypothesis-4.34.0
collecting ... collected 1 item

test_integration_pr2.py::TestCollisionAvoidanceGoals::test_ease_cereal started roslaunch server http://thomas-MS-7C91:41095/

SUMMARY
========

PARAMETERS
 * /rosdistro: melodic
 * /rosversion: 1.14.10

NODES

ROS_MASTER_URI=http://localhost:11311
process[joint_trajectory_splitter-1]: started with pid [21277]
[INFO] [1622711408.350452]: [/tests]: --> added ground_plane to world
[INFO] [1622711408.354035]: [/tests]: --> added pybullet_hack to world
[INFO] [1622711408.814896]: [/tests]: --> added pr2 to world
[INFO] [1622711408.951449]: [/tests]: loaded self collision matrix tmp_data/collision_matrix//pr2/b0057f62f931d87bc6455fc9444aa08e
[INFO] [1622711408.958210]: [/tests]: waiting for action server '/whole_body_controller/follow_joint_trajectory' to appear
[INFO] [1622711408.958839]: [/tests]: successfully connected to action server
[INFO] [1622711408.965280]: [/tests]: Writing tmp_data/tree.dot/svg/png
[INFO] [1622711411.155347]: [/tests]: resetting giskard
[INFO] [1622711411.161029]: [/tests]: <-- removed object pybullet_hack from world
[INFO] [1622711411.162108]: [/tests]: <-- removed object ground_plane from world
[INFO] [1622711411.395659]: [/tests]: loaded self collision matrix tmp_data/collision_matrix//pr2/b0057f62f931d87bc6455fc9444aa08e
[INFO] [1622711411.399757]: [/tests]: --> added ground_plane to world
[INFO] [1622711411.403539]: [/tests]: --> added pybullet_hack to world
[INFO] [1622711412.534907]: [/tests]: parsing goal message
[INFO] [1622711412.535791]: [/tests]: adding constraint of type: 'JointPositionList'
[INFO] [1622711412.539761]: [/tests]: done parsing goal message
[INFO] [1622711413.212272]: [/tests]: constructing new controller with 17 soft constraints...
[INFO] [1622711413.213711]: [/tests]: computed Jacobian in 0.00019s
[INFO] [1622711413.215578]: [/tests]: compiled symbolic expressions in 0.00074s
[INFO] [1622711413.352521]: [/tests]: found loop, stopped planning.
[INFO] [1622711413.353326]: [/tests]: found goal trajectory with length 1.05s in 0.812873840332s
[INFO] [1622711417.114326]: [/tests]: --> added kitchen to world
FAILED [100%][INFO] [1622711418.233149]: [/tests]: --> added cereal to world
[INFO] [1622711418.881745]: [/tests]: adding 39 external collision avoidance constraints
[INFO] [1622711418.946624]: [/tests]: adding 67 self collision avoidance constraints
[INFO] [1622711418.947797]: [/tests]: parsing goal message
[INFO] [1622711418.948374]: [/tests]: adding constraint of type: 'BasePointingForward'
[INFO] [1622711418.952238]: [/tests]: adding constraint of type: 'AvoidJointLimits'
[INFO] [1622711418.957091]: [/tests]: adding constraint of type: 'CartesianPosition'
[INFO] [1622711418.958691]: [/tests]: adding constraint of type: 'CartesianOrientationSlerp'
[INFO] [1622711418.970132]: [/tests]: done parsing goal message
[INFO] [1622711419.023125]: [/tests]: constructing new controller with 128 soft constraints...
[INFO] [1622711419.066297]: [/tests]: computed Jacobian in 0.04026s
[INFO] [1622711419.089189]: [/tests]: compiled symbolic expressions in 0.01803s
Traceback (most recent call last):
  File "/home/thomas/ros_ws/src/giskardpy/src/giskardpy/plugin.py", line 158, in loop_over_plugins
    for node in plugin.tick():
  File "/opt/ros/melodic/lib/python2.7/dist-packages/py_trees/behaviour.py", line 249, in tick
    new_status = self.update()
  File "/home/thomas/ros_ws/src/giskardpy/src/giskardpy/plugin_interrupts.py", line 76, in update
    raise e
ShakingException: endless wiggling detected
shaking of joint: 'odom_z_joint' at 10.0 hertz: 0.561485864631 > 0.55

test/test_integration_pr2.py:7217 (TestCollisionAvoidanceGoals.test_ease_cereal)
self = <test_integration_pr2.TestCollisionAvoidanceGoals object at 0x7fb3c1446310>
kitchen_setup = <utils_for_tests.PR2 object at 0x7fb3c14466d0>

    def test_ease_cereal(self, kitchen_setup):
        # FIXME shaky af
        cereal_name = u'cereal'
        drawer_frame_id = u'iai_kitchen/oven_area_area_right_drawer_board_3_link'
    
        # take milk out of fridge
        kitchen_setup.set_kitchen_js({u'oven_area_area_right_drawer_main_joint': 0.48})
    
        kitchen_setup.set_json_goal(u'BasePointingForward')
    
        # spawn milk
    
        cereal_pose = PoseStamped()
        cereal_pose.header.frame_id = drawer_frame_id
        cereal_pose.pose.position = Point(0.123, -0.03, 0.11)
        cereal_pose.pose.orientation = Quaternion(0.0087786, 0.005395, -0.838767, -0.544393)
        kitchen_setup.add_box(cereal_name, [0.1528, 0.0634, 0.22894], cereal_pose)
    
        drawer_T_box = tf.msg_to_kdl(cereal_pose)
    
        # grasp milk
        kitchen_setup.open_l_gripper()
        grasp_pose = PoseStamped()
        grasp_pose.header.frame_id = cereal_name
        grasp_pose.pose.position = Point(0.1, 0, 0)
        grasp_pose.pose.orientation = Quaternion(0, 0, 1, 0)
        box_T_r_goal = tf.msg_to_kdl(grasp_pose)
        box_T_r_goal_pre = deepcopy(box_T_r_goal)
        box_T_r_goal_pre.p[0] += 0.1
    
        grasp_pose = tf.kdl_to_pose_stamped(drawer_T_box * box_T_r_goal_pre, drawer_frame_id)
    
        kitchen_setup.set_json_goal(u'AvoidJointLimits', percentage=40)
>       kitchen_setup.set_and_check_cart_goal(grasp_pose, tip_link=kitchen_setup.r_tip)

test_integration_pr2.py:7251: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
utils_for_tests.py:441: in set_and_check_cart_goal
    self.send_and_check_goal(expected_error_codes)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <utils_for_tests.PR2 object at 0x7fb3c14466d0>
expected_error_codes = None, goal_type = 5, goal = None

    def send_and_check_goal(self, expected_error_codes=None, goal_type=MoveGoal.PLAN_AND_EXECUTE, goal=None):
        r = self.send_goal(goal=goal, goal_type=goal_type)
        for i in range(len(r.error_codes)):
            error_code = r.error_codes[i]
            error_message = r.error_messages[i]
            if expected_error_codes is None:
                expected_error_code = MoveResult.SUCCESS
            else:
                expected_error_code = expected_error_codes[i]
            assert error_code == expected_error_code, \
                u'in goal {}; got: {}, expected: {} | error_massage: {}'.format(i, move_result_error_code(error_code),
                                                                                move_result_error_code(
                                                                                    expected_error_code),
>                                                                               error_message)
E           AssertionError: in goal 0; got: SHAKING, expected: SUCCESS | error_massage: endless wiggling detected
E           shaking of joint: 'odom_z_joint' at 10.0 hertz: 0.561485864631 > 0.55

utils_for_tests.py:546: AssertionError
[INFO] [1622711422.432388]: [/tests]: total time spend giskarding: 5.20972895622
[INFO] [1622711422.434210]: [/tests]: total time spend moving: 2.51886796951
[INFO] [1622711422.434867]: [/tests]: stopping plugins
[INFO] [1622711422.637019]: [/tests]: shutdown ros
[joint_trajectory_splitter-1] process has died without exit code [pid 21277, cmd /home/thomas/ros_ws/src/giskardpy/scripts/joint_trajectory_splitter.py __name:=joint_trajectory_splitter __log:=/home/thomas/.ros/log/640cf914-c443-11eb-902c-00e18c544462/joint_trajectory_splitter-1.log].
log file: /home/thomas/.ros/log/640cf914-c443-11eb-902c-00e18c544462/joint_trajectory_splitter-1*.log
[INFO] [1622711422.785772]: [/tests]: deleting tmp test folder
[WARN] [1622711422.625310]: Inbound TCP/IP connection failed: connection from sender terminated before handshake header received. 0 bytes were received. Please check sender for additional details.






=================================== FAILURES ===================================
_________________ TestCollisionAvoidanceGoals.test_ease_cereal _________________

self = <test_integration_pr2.TestCollisionAvoidanceGoals object at 0x7fb3c1446310>
kitchen_setup = <utils_for_tests.PR2 object at 0x7fb3c14466d0>

    def test_ease_cereal(self, kitchen_setup):
        # FIXME shaky af
        cereal_name = u'cereal'
        drawer_frame_id = u'iai_kitchen/oven_area_area_right_drawer_board_3_link'
    
        # take milk out of fridge
        kitchen_setup.set_kitchen_js({u'oven_area_area_right_drawer_main_joint': 0.48})
    
        kitchen_setup.set_json_goal(u'BasePointingForward')
    
        # spawn milk
    
        cereal_pose = PoseStamped()
        cereal_pose.header.frame_id = drawer_frame_id
        cereal_pose.pose.position = Point(0.123, -0.03, 0.11)
        cereal_pose.pose.orientation = Quaternion(0.0087786, 0.005395, -0.838767, -0.544393)
        kitchen_setup.add_box(cereal_name, [0.1528, 0.0634, 0.22894], cereal_pose)
    
        drawer_T_box = tf.msg_to_kdl(cereal_pose)
    
        # grasp milk
        kitchen_setup.open_l_gripper()
        grasp_pose = PoseStamped()
        grasp_pose.header.frame_id = cereal_name
        grasp_pose.pose.position = Point(0.1, 0, 0)
        grasp_pose.pose.orientation = Quaternion(0, 0, 1, 0)
        box_T_r_goal = tf.msg_to_kdl(grasp_pose)
        box_T_r_goal_pre = deepcopy(box_T_r_goal)
        box_T_r_goal_pre.p[0] += 0.1
    
        grasp_pose = tf.kdl_to_pose_stamped(drawer_T_box * box_T_r_goal_pre, drawer_frame_id)
    
        kitchen_setup.set_json_goal(u'AvoidJointLimits', percentage=40)
>       kitchen_setup.set_and_check_cart_goal(grasp_pose, tip_link=kitchen_setup.r_tip)

test_integration_pr2.py:7251: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
utils_for_tests.py:441: in set_and_check_cart_goal
    self.send_and_check_goal(expected_error_codes)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <utils_for_tests.PR2 object at 0x7fb3c14466d0>
expected_error_codes = None, goal_type = 5, goal = None

    def send_and_check_goal(self, expected_error_codes=None, goal_type=MoveGoal.PLAN_AND_EXECUTE, goal=None):
        r = self.send_goal(goal=goal, goal_type=goal_type)
        for i in range(len(r.error_codes)):
            error_code = r.error_codes[i]
            error_message = r.error_messages[i]
            if expected_error_codes is None:
                expected_error_code = MoveResult.SUCCESS
            else:
                expected_error_code = expected_error_codes[i]
            assert error_code == expected_error_code, \
                u'in goal {}; got: {}, expected: {} | error_massage: {}'.format(i, move_result_error_code(error_code),
                                                                                move_result_error_code(
                                                                                    expected_error_code),
>                                                                               error_message)
E           AssertionError: in goal 0; got: SHAKING, expected: SUCCESS | error_massage: endless wiggling detected
E           shaking of joint: 'odom_z_joint' at 10.0 hertz: 0.561485864631 > 0.55

utils_for_tests.py:546: AssertionError
---------------------------- Captured stdout setup -----------------------------
started roslaunch server http://thomas-MS-7C91:41095/

SUMMARY
========

PARAMETERS
 * /rosdistro: melodic
 * /rosversion: 1.14.10

NODES

ROS_MASTER_URI=http://localhost:11311
process[joint_trajectory_splitter-1]: started with pid [21277]
[INFO] [1622711408.350452]: [/tests]: --> added ground_plane to world
[INFO] [1622711408.354035]: [/tests]: --> added pybullet_hack to world
[INFO] [1622711408.814896]: [/tests]: --> added pr2 to world
[INFO] [1622711408.951449]: [/tests]: loaded self collision matrix tmp_data/collision_matrix//pr2/b0057f62f931d87bc6455fc9444aa08e
[INFO] [1622711408.958210]: [/tests]: waiting for action server '/whole_body_controller/follow_joint_trajectory' to appear
[INFO] [1622711408.958839]: [/tests]: successfully connected to action server
[INFO] [1622711408.965280]: [/tests]: Writing tmp_data/tree.dot/svg/png
[INFO] [1622711411.155347]: [/tests]: resetting giskard
[INFO] [1622711411.161029]: [/tests]: <-- removed object pybullet_hack from world
[INFO] [1622711411.162108]: [/tests]: <-- removed object ground_plane from world
[INFO] [1622711411.395659]: [/tests]: loaded self collision matrix tmp_data/collision_matrix//pr2/b0057f62f931d87bc6455fc9444aa08e
[INFO] [1622711411.399757]: [/tests]: --> added ground_plane to world
[INFO] [1622711411.403539]: [/tests]: --> added pybullet_hack to world
[INFO] [1622711412.534907]: [/tests]: parsing goal message
[INFO] [1622711412.535791]: [/tests]: adding constraint of type: 'JointPositionList'
[INFO] [1622711412.539761]: [/tests]: done parsing goal message
[INFO] [1622711413.212272]: [/tests]: constructing new controller with 17 soft constraints...
[INFO] [1622711413.213711]: [/tests]: computed Jacobian in 0.00019s
[INFO] [1622711413.215578]: [/tests]: compiled symbolic expressions in 0.00074s
[INFO] [1622711413.352521]: [/tests]: found loop, stopped planning.
[INFO] [1622711413.353326]: [/tests]: found goal trajectory with length 1.05s in 0.812873840332s
[INFO] [1622711417.114326]: [/tests]: --> added kitchen to world
------------------------------ Captured log setup ------------------------------
logging.py                  49 INFO     [/unnamed]: deleting tmp test folder
logging.py                  49 INFO     [/unnamed]: init ros
----------------------------- Captured stdout call -----------------------------
[INFO] [1622711418.233149]: [/tests]: --> added cereal to world
[INFO] [1622711418.881745]: [/tests]: adding 39 external collision avoidance constraints
[INFO] [1622711418.946624]: [/tests]: adding 67 self collision avoidance constraints
[INFO] [1622711418.947797]: [/tests]: parsing goal message
[INFO] [1622711418.948374]: [/tests]: adding constraint of type: 'BasePointingForward'
[INFO] [1622711418.952238]: [/tests]: adding constraint of type: 'AvoidJointLimits'
[INFO] [1622711418.957091]: [/tests]: adding constraint of type: 'CartesianPosition'
[INFO] [1622711418.958691]: [/tests]: adding constraint of type: 'CartesianOrientationSlerp'
[INFO] [1622711418.970132]: [/tests]: done parsing goal message
[INFO] [1622711419.023125]: [/tests]: constructing new controller with 128 soft constraints...
[INFO] [1622711419.066297]: [/tests]: computed Jacobian in 0.04026s
[INFO] [1622711419.089189]: [/tests]: compiled symbolic expressions in 0.01803s
----------------------------- Captured stderr call -----------------------------
Traceback (most recent call last):
  File "/home/thomas/ros_ws/src/giskardpy/src/giskardpy/plugin.py", line 158, in loop_over_plugins
    for node in plugin.tick():
  File "/opt/ros/melodic/lib/python2.7/dist-packages/py_trees/behaviour.py", line 249, in tick
    new_status = self.update()
  File "/home/thomas/ros_ws/src/giskardpy/src/giskardpy/plugin_interrupts.py", line 76, in update
    raise e
ShakingException: endless wiggling detected
shaking of joint: 'odom_z_joint' at 10.0 hertz: 0.561485864631 > 0.55
------------------------------ Captured log call -------------------------------
tcpros_base.py             640 DEBUG    [/tests/update_world]: writing header
tcpros_service.py          233 DEBUG    connection from 127.0.0.1:60300
tcpros_base.py             640 DEBUG    [/tests/update_world]: writing header
logging.py                  49 INFO     [/tests]: --> added cereal to world
tcpros_base.py             640 DEBUG    [/tests/get_object_names]: writing header
tcpros_service.py          233 DEBUG    connection from 127.0.0.1:60304
tcpros_base.py             640 DEBUG    [/tests/get_object_names]: writing header
tcpros_base.py             640 DEBUG    [/tests/get_object_info]: writing header
tcpros_service.py          233 DEBUG    connection from 127.0.0.1:60308
tcpros_base.py             640 DEBUG    [/tests/get_object_info]: writing header
tcpros_base.py             640 DEBUG    [/l_gripper_simulator/set_joint_states]: writing header
logging.py                  49 INFO     [/tests]: adding 39 external collision avoidance constraints
logging.py                  49 INFO     [/tests]: adding 67 self collision avoidance constraints
logging.py                  49 INFO     [/tests]: parsing goal message
logging.py                  49 INFO     [/tests]: adding constraint of type: 'BasePointingForward'
logging.py                  49 INFO     [/tests]: adding constraint of type: 'AvoidJointLimits'
logging.py                  49 INFO     [/tests]: adding constraint of type: 'CartesianPosition'
logging.py                  49 INFO     [/tests]: adding constraint of type: 'CartesianOrientationSlerp'
logging.py                  49 INFO     [/tests]: done parsing goal message
logging.py                  49 INFO     [/tests]: constructing new controller with 128 soft constraints...
logging.py                  49 INFO     [/tests]: computed Jacobian in 0.04026s
logging.py                  49 INFO     [/tests]: compiled symbolic expressions in 0.01803s
--------------------------- Captured stdout teardown ---------------------------
[INFO] [1622711422.432388]: [/tests]: total time spend giskarding: 5.20972895622
[INFO] [1622711422.434210]: [/tests]: total time spend moving: 2.51886796951
[INFO] [1622711422.434867]: [/tests]: stopping plugins
[INFO] [1622711422.637019]: [/tests]: shutdown ros
[joint_trajectory_splitter-1] process has died without exit code [pid 21277, cmd /home/thomas/ros_ws/src/giskardpy/scripts/joint_trajectory_splitter.py __name:=joint_trajectory_splitter __log:=/home/thomas/.ros/log/640cf914-c443-11eb-902c-00e18c544462/joint_trajectory_splitter-1.log].
log file: /home/thomas/.ros/log/640cf914-c443-11eb-902c-00e18c544462/joint_trajectory_splitter-1*.log
[INFO] [1622711422.785772]: [/tests]: deleting tmp test folder
--------------------------- Captured stderr teardown ---------------------------
[WARN] [1622711422.625310]: Inbound TCP/IP connection failed: connection from sender terminated before handshake header received. 0 bytes were received. Please check sender for additional details.
---------------------------- Captured log teardown -----------------------------
logging.py                  49 INFO     [/tests]: total time spend giskarding: 5.20972895622
logging.py                  49 INFO     [/tests]: total time spend moving: 2.51886796951
logging.py                  49 INFO     [/tests]: stopping plugins
nodeprocess.py             503 DEBUG    process[joint_trajectory_splitter-1].stop() starting
nodeprocess.py             402 INFO     process[joint_trajectory_splitter-1]: killing os process with pid[21277] pgid[21277]
nodeprocess.py             406 INFO     [joint_trajectory_splitter-1] sending SIGINT to pgid [21277]
nodeprocess.py             408 INFO     [joint_trajectory_splitter-1] sent SIGINT to pgid [21277]
tcpros_base.py             640 DEBUG    [/whole_body_controller/follow_joint_trajectory/result]: writing header
core.py                    143 ERROR    Unable to initiate TCP/IP socket to thomas-MS-7C91:36979 (http://thomas-MS-7C91:41133/): Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 562, in connect
    self.read_header()
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 657, in read_header
    self._validate_header(read_ros_handshake_header(sock, self.read_buff, self.protocol.buff_size))
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 600, in _validate_header
    raise TransportInitError("remote error reported: %s"%header['error'])
TransportInitError: remote error reported: node shutting down

tcpros_base.py             640 DEBUG    [/whole_body_controller/follow_joint_trajectory/status]: writing header
core.py                    143 ERROR    Unable to initiate TCP/IP socket to thomas-MS-7C91:36979 (http://thomas-MS-7C91:41133/): Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 562, in connect
    self.read_header()
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 657, in read_header
    self._validate_header(read_ros_handshake_header(sock, self.read_buff, self.protocol.buff_size))
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 600, in _validate_header
    raise TransportInitError("remote error reported: %s"%header['error'])
TransportInitError: remote error reported: node shutting down

tcpros_base.py             640 DEBUG    [/whole_body_controller/follow_joint_trajectory/feedback]: writing header
core.py                    143 ERROR    Unable to initiate TCP/IP socket to thomas-MS-7C91:36979 (http://thomas-MS-7C91:41133/): Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 562, in connect
    self.read_header()
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 657, in read_header
    self._validate_header(read_ros_handshake_header(sock, self.read_buff, self.protocol.buff_size))
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 600, in _validate_header
    raise TransportInitError("remote error reported: %s"%header['error'])
TransportInitError: remote error reported: node shutting down

masterslave.py             115 DEBUG    publisherUpdate('/master', '/whole_body_controller/follow_joint_trajectory/result', [])
masterslave.py             147 DEBUG    publisherUpdate('/master', '/whole_body_controller/follow_joint_trajectory/result', []) returns (1, '', 0)
masterslave.py             115 DEBUG    publisherUpdate('/master', '/whole_body_controller/follow_joint_trajectory/status', [])
masterslave.py             147 DEBUG    publisherUpdate('/master', '/whole_body_controller/follow_joint_trajectory/status', []) returns (1, '', 0)
masterslave.py             115 DEBUG    publisherUpdate('/master', '/whole_body_controller/follow_joint_trajectory/feedback', [])
masterslave.py             147 DEBUG    publisherUpdate('/master', '/whole_body_controller/follow_joint_trajectory/feedback', []) returns (1, '', 0)
tcpros_base.py             355 WARNING  Inbound TCP/IP connection failed: connection from sender terminated before handshake header received. 0 bytes were received. Please check sender for additional details.
core.py                    143 ERROR    Inbound TCP/IP connection failed:
Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 325, in _tcp_server_callback
    header = read_ros_handshake_header(sock, StringIO(), buff_size)
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rosgraph/network.py", line 359, in read_ros_handshake_header
    raise ROSHandshakeException("connection from sender terminated before handshake header received. %s bytes were received. Please check sender for additional details."%b.tell())
ROSHandshakeException: connection from sender terminated before handshake header received. 0 bytes were received. Please check sender for additional details.

nodeprocess.py             444 INFO     process[joint_trajectory_splitter-1]: SIGINT killed with return value 0
logging.py                  49 INFO     [/tests]: shutdown ros
core.py                    560 INFO     signal_shutdown [die]
registration.py            336 DEBUG    registration cleanup starting
registration.py            365 DEBUG    unregisterSubscriber [/kitchen/joint_states]
registration.py            365 DEBUG    unregisterSubscriber [/tests/command/feedback]
registration.py            365 DEBUG    unregisterSubscriber [/whole_body_controller/follow_joint_trajectory/result]
registration.py            365 DEBUG    unregisterSubscriber [/joint_states]
registration.py            365 DEBUG    unregisterSubscriber [/tests/command/result]
registration.py            365 DEBUG    unregisterSubscriber [/tf]
registration.py            365 DEBUG    unregisterSubscriber [/tf_static]
registration.py            365 DEBUG    unregisterSubscriber [/whole_body_controller/follow_joint_trajectory/goal]
registration.py            365 DEBUG    unregisterSubscriber [/whole_body_controller/follow_joint_trajectory/status]
registration.py            365 DEBUG    unregisterSubscriber [/tests/command/goal]
registration.py            365 DEBUG    unregisterSubscriber [/tests/command/cancel]
registration.py            365 DEBUG    unregisterSubscriber [/whole_body_controller/follow_joint_trajectory/feedback]
registration.py            365 DEBUG    unregisterSubscriber [/tests/command/status]
registration.py            368 DEBUG    unregisterPublisher [/tests/visualization_marker_array]
registration.py            368 DEBUG    unregisterPublisher [/whole_body_controller/follow_joint_trajectory/goal]
registration.py            368 DEBUG    unregisterPublisher [/tests/command/feedback]
registration.py            368 DEBUG    unregisterPublisher [/visualization_marker_array]
registration.py            368 DEBUG    unregisterPublisher [/tests/introspection/publishers]
registration.py            368 DEBUG    unregisterPublisher [/tests/blackboard]
registration.py            368 DEBUG    unregisterPublisher [/rosout]
registration.py            368 DEBUG    unregisterPublisher [/tests/command/result]
registration.py            368 DEBUG    unregisterPublisher [/tf]
registration.py            368 DEBUG    unregisterPublisher [/tests/tip]
registration.py            368 DEBUG    unregisterPublisher [/move_base_simple/goal]
registration.py            368 DEBUG    unregisterPublisher [/tests/ascii/tree]
registration.py            368 DEBUG    unregisterPublisher [/tests/command/goal]
registration.py            368 DEBUG    unregisterPublisher [/tests/log/tree]
registration.py            368 DEBUG    unregisterPublisher [/tests/command/cancel]
registration.py            368 DEBUG    unregisterPublisher [/tests/ascii/snapshot]
registration.py            368 DEBUG    unregisterPublisher [/tests/command/status]
registration.py            368 DEBUG    unregisterPublisher [/kitchen/cram_joint_states]
registration.py            368 DEBUG    unregisterPublisher [/tests/dot/tree]
registration.py            368 DEBUG    unregisterPublisher [/whole_body_controller/follow_joint_trajectory/cancel]
registration.py            373 DEBUG    unregisterService [/tests/get_blackboard_variables]
registration.py            373 DEBUG    unregisterService [/tests/get_attached_objects]
registration.py            373 DEBUG    unregisterService [/tests/set_logger_level]
registration.py            373 DEBUG    unregisterService [/tests/dump_state]
registration.py            373 DEBUG    unregisterService [/tests/get_object_names]
registration.py            373 DEBUG    unregisterService [/tests/update_rviz_markers]
registration.py            373 DEBUG    unregisterService [/tests/close_blackboard_watcher]
registration.py            373 DEBUG    unregisterService [/tests/update_world]
registration.py            373 DEBUG    unregisterService [/tests/open_blackboard_watcher]
registration.py            373 DEBUG    unregisterService [/tests/get_object_info]
registration.py            373 DEBUG    unregisterService [/tests/get_loggers]
registration.py            373 DEBUG    unregisterService [/tests/render]
registration.py            373 DEBUG    unregisterService [/tests/tf2_frames]
registration.py            385 DEBUG    registration cleanup: master calls complete
core.py                    140 INFO     topic[/tests/visualization_marker_array] removing connection to /rviz_1622710689079853762
core.py                    140 INFO     topic[/whole_body_controller/follow_joint_trajectory/goal] removing connection to /tests
tcpros_base.py             640 DEBUG    [/whole_body_controller/follow_joint_trajectory/goal]: writing header
core.py                    140 INFO     topic[/whole_body_controller/follow_joint_trajectory/goal] removing connection to /joint_trajectory_splitter
core.py                    140 INFO     topic[/tests/command/feedback] removing connection to /tests
core.py                    143 ERROR    Unable to initiate TCP/IP socket to thomas-MS-7C91:45697 (http://thomas-MS-7C91:36215/): Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 562, in connect
    self.read_header()
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 657, in read_header
    self._validate_header(read_ros_handshake_header(sock, self.read_buff, self.protocol.buff_size))
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 600, in _validate_header
    raise TransportInitError("remote error reported: %s"%header['error'])
TransportInitError: remote error reported: node shutting down

tcpros_base.py             640 DEBUG    [/tests/command/feedback]: writing header
core.py                    140 INFO     topic[/rosout] removing connection to /rosout
core.py                    140 INFO     topic[/tests/command/result] removing connection to /tests
core.py                    140 INFO     topic[/tf] removing connection to /base_controller
core.py                    143 ERROR    Unable to initiate TCP/IP socket to thomas-MS-7C91:45697 (http://thomas-MS-7C91:36215/): Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 562, in connect
    self.read_header()
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 657, in read_header
    self._validate_header(read_ros_handshake_header(sock, self.read_buff, self.protocol.buff_size))
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 600, in _validate_header
    raise TransportInitError("remote error reported: %s"%header['error'])
TransportInitError: remote error reported: node shutting down

tcpros_base.py             640 DEBUG    [/tests/command/result]: writing header
core.py                    140 INFO     topic[/tf] removing connection to /tests
tcpros_base.py             640 DEBUG    [/tf]: writing header
core.py                    143 ERROR    Unable to initiate TCP/IP socket to thomas-MS-7C91:45697 (http://thomas-MS-7C91:36215/): Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 562, in connect
    self.read_header()
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 657, in read_header
    self._validate_header(read_ros_handshake_header(sock, self.read_buff, self.protocol.buff_size))
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 600, in _validate_header
    raise TransportInitError("remote error reported: %s"%header['error'])
TransportInitError: remote error reported: node shutting down

core.py                    140 INFO     topic[/tf] removing connection to /tf2_buffer_server
core.py                    140 INFO     topic[/tf] removing connection to /rviz_1622710689079853762
core.py                    143 ERROR    Unable to initiate TCP/IP socket to thomas-MS-7C91:45697 (http://thomas-MS-7C91:36215/): Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 562, in connect
    self.read_header()
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 657, in read_header
    self._validate_header(read_ros_handshake_header(sock, self.read_buff, self.protocol.buff_size))
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 600, in _validate_header
    raise TransportInitError("remote error reported: %s"%header['error'])
TransportInitError: remote error reported: node shutting down

core.py                    140 INFO     topic[/tests/command/goal] removing connection to /tests
tcpros_base.py             640 DEBUG    [/tests/command/goal]: writing header
core.py                    140 INFO     topic[/tests/command/cancel] removing connection to /tests
core.py                    140 INFO     topic[/tests/command/status] removing connection to /tests
tcpros_base.py             640 DEBUG    [/tests/command/cancel]: writing header
core.py                    143 ERROR    Unable to initiate TCP/IP socket to thomas-MS-7C91:45697 (http://thomas-MS-7C91:36215/): Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 562, in connect
    self.read_header()
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 657, in read_header
    self._validate_header(read_ros_handshake_header(sock, self.read_buff, self.protocol.buff_size))
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 600, in _validate_header
    raise TransportInitError("remote error reported: %s"%header['error'])
TransportInitError: remote error reported: node shutting down

core.py                    140 INFO     topic[/kitchen/cram_joint_states] removing connection to /kitchen_joint_state_publisher
tcpros_base.py             640 DEBUG    [/tests/command/status]: writing header
core.py                    143 ERROR    Unable to initiate TCP/IP socket to thomas-MS-7C91:45697 (http://thomas-MS-7C91:36215/): Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 562, in connect
    self.read_header()
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 657, in read_header
    self._validate_header(read_ros_handshake_header(sock, self.read_buff, self.protocol.buff_size))
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 600, in _validate_header
    raise TransportInitError("remote error reported: %s"%header['error'])
TransportInitError: remote error reported: node shutting down

core.py                    140 INFO     topic[/whole_body_controller/follow_joint_trajectory/cancel] removing connection to /joint_trajectory_splitter
core.py                    143 ERROR    Unable to initiate TCP/IP socket to thomas-MS-7C91:45697 (http://thomas-MS-7C91:36215/): Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 562, in connect
    self.read_header()
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 657, in read_header
    self._validate_header(read_ros_handshake_header(sock, self.read_buff, self.protocol.buff_size))
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 600, in _validate_header
    raise TransportInitError("remote error reported: %s"%header['error'])
TransportInitError: remote error reported: node shutting down

core.py                    137 DEBUG    receive_loop[/kitchen/joint_states]: done condition met, exited loop
core.py                    140 INFO     topic[/kitchen/joint_states] removing connection to http://thomas-MS-7C91:45379/
core.py                    140 INFO     topic[/tests/command/feedback] removing connection to http://thomas-MS-7C91:36215/
core.py                    140 INFO     topic[/whole_body_controller/follow_joint_trajectory/result] removing connection to http://thomas-MS-7C91:41133/
core.py                    140 INFO     topic[/joint_states] removing connection to http://thomas-MS-7C91:46591/
core.py                    140 INFO     topic[/tests/command/result] removing connection to http://thomas-MS-7C91:36215/
core.py                    143 ERROR    Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 737, in receive_once
    self.stat_bytes += recv_buff(sock, b, p.buff_size)
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 104, in recv_buff
    d = sock.recv(buff_size)
error: [Errno 104] Connection reset by peer

core.py                    140 INFO     topic[/tf] removing connection to http://thomas-MS-7C91:39257/
core.py                    137 DEBUG    receive_loop[/tf]: done condition met, exited loop
core.py                    137 DEBUG    receive_loop[/joint_states]: done condition met, exited loop
core.py                    140 INFO     topic[/tf] removing connection to http://thomas-MS-7C91:33195/
core.py                    137 DEBUG    receive_loop[/tf]: done condition met, exited loop
core.py                    140 INFO     topic[/tf] removing connection to http://thomas-MS-7C91:40133/
core.py                    143 ERROR    Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 737, in receive_once
    self.stat_bytes += recv_buff(sock, b, p.buff_size)
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 104, in recv_buff
    d = sock.recv(buff_size)
error: [Errno 104] Connection reset by peer

core.py                    140 INFO     topic[/tf] removing connection to http://thomas-MS-7C91:40155/
core.py                    137 DEBUG    receive_loop[/tf]: done condition met, exited loop
core.py                    146 WARNING  Unknown error initiating TCP/IP socket to thomas-MS-7C91:34975 (http://thomas-MS-7C91:40155/): Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 562, in connect
    self.read_header()
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 657, in read_header
    self._validate_header(read_ros_handshake_header(sock, self.read_buff, self.protocol.buff_size))
AttributeError: 'NoneType' object has no attribute 'buff_size'

topics.py                  329 ERROR    Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/topics.py", line 326, in close
    c.close()
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 846, in close
    self.socket.close()
AttributeError: 'NoneType' object has no attribute 'close'

core.py                    140 INFO     topic[/tf] removing connection to http://thomas-MS-7C91:36215/
core.py                    140 INFO     topic[/tf_static] removing connection to http://thomas-MS-7C91:33195/
core.py                    137 DEBUG    receive_loop[/tf_static]: done condition met, exited loop
core.py                    140 INFO     topic[/tf_static] removing connection to http://thomas-MS-7C91:40133/
core.py                    140 INFO     topic[/whole_body_controller/follow_joint_trajectory/goal] removing connection to http://thomas-MS-7C91:36215/
core.py                    140 INFO     topic[/whole_body_controller/follow_joint_trajectory/status] removing connection to http://thomas-MS-7C91:41133/
core.py                    146 WARNING  Unknown error initiating TCP/IP socket to thomas-MS-7C91:48941 (http://thomas-MS-7C91:40133/): Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 562, in connect
    self.read_header()
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 657, in read_header
    self._validate_header(read_ros_handshake_header(sock, self.read_buff, self.protocol.buff_size))
AttributeError: 'NoneType' object has no attribute 'buff_size'

core.py                    140 INFO     topic[/tests/command/goal] removing connection to http://thomas-MS-7C91:36215/
core.py                    140 INFO     topic[/tests/command/cancel] removing connection to http://thomas-MS-7C91:36215/
core.py                    140 INFO     topic[/whole_body_controller/follow_joint_trajectory/feedback] removing connection to http://thomas-MS-7C91:41133/
core.py                    140 INFO     topic[/tests/command/status] removing connection to http://thomas-MS-7C91:36215/
masterslave.py             342 INFO     die
pmon.py                    564 DEBUG    Process[joint_trajectory_splitter-1] has died, respawn=False, required=False, exit_code=None
pmon.py                    380 INFO     ProcessMonitor.unregister[joint_trajectory_splitter-1] starting
pmon.py                    383 INFO     ProcessMonitor.unregister[joint_trajectory_splitter-1] complete
nodeprocess.py             503 DEBUG    process[joint_trajectory_splitter-1].stop() starting
nodeprocess.py             505 DEBUG    process[%s].stop(): popen is None, nothing to kill
logging.py                  49 INFO     [/tests]: deleting tmp test folder
=============================== warnings summary ===============================
test/test_integration_pr2.py::TestCollisionAvoidanceGoals::()::test_ease_cereal
  /home/thomas/ros_ws/src/giskardpy/test/utils_for_tests.py:229: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
    config = yaml.load(f)

-- Docs: http://doc.pytest.org/en/latest/warnings.html
==================== 1 failed, 1 warnings in 21.25 seconds =====================

Process finished with exit code 1

```
</details>

