### PR TITLE
[e-stop] fixed for new joystick of pr2

### DIFF
--- a/launch/giskardpy_pr2_iai.launch
+++ b/launch/giskardpy_pr2_iai.launch
@@ -1,10 +1,12 @@
 <launch>
 
-  <node pkg="giskardpy" type="giskard_pr2_iai.py" name="giskard" output="screen"/>
+  <node pkg="giskardpy" type="giskard.py" name="giskard" output="screen">
+    <param name="config" value="PR2_IAI"/>
+  </node>
 
   <node pkg="giskardpy" type="joystick_e_stop.py" name="giskard_e_stop" output="screen">
     <rosparam param="button_ids">
-        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
     </rosparam>
   </node>
 

--- a/scripts/joystick_e_stop.py
+++ b/scripts/joystick_e_stop.py
@@ -29,7 +29,11 @@ class MUH:
 
 
 rospy.init_node('giskard_e_stop')
-button_ids = rospy.get_param('~button_ids', default=list(range(17)))
+
+joy_msg: Joy = rospy.wait_for_message('/joy', Joy)
+num_buttons = len(joy_msg.buttons)
+
+button_ids = rospy.get_param('~button_ids', default=list(range(num_buttons)))
 muh = MUH(button_ids)
 logging.loginfo('giskard joystick e stop is running')
 rospy.spin()


### PR DESCRIPTION
fixed the joystick e-stop which broke due to the new joystick controller for the pr2. 
Tested on the real pr2, it now works again and the node does no longer crash on startup.

Kind regards,
Alexis and Alina