### PR TITLE
replace pull_request with pull_request_target in tigger_giskardpy_ros_ci_standalone.yml

### DIFF
--- a/.github/workflows/trigger_giskardpy_ros_ci_standalone.yml
+++ b/.github/workflows/trigger_giskardpy_ros_ci_standalone.yml
@@ -1,6 +1,6 @@
 name: Trigger giskardpy_ros ros1-noetic-main Tests
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
   push:
     branches:
@@ -30,7 +30,7 @@ jobs:
       # Triggers ci_standalone workflow of giskardpy_ros repo. Needs setup secret token to work
       - name: Trigger workflow in giskardpy_ros
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
+          if [ "${{ github.event_name }}" = "pull_request_target" ]; then
             DATA='{
               "ref":"${{ matrix.branch }}",
               "inputs": {


### PR DESCRIPTION
setup pull_request_target to allow prs from forks access to secrets.giskardpy_ros_test_trigger
pull_request_target has access to secrects and should be used with caution to avoid repository compromise.
(https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/)

Could add check for pr-label to run workflow to increase security by having to manually label a given PR, before workflow can run