### PR TITLE
tick_until_end resets vel after it ends

### DIFF
--- a/giskardpy/executor.py
+++ b/giskardpy/executor.py
@@ -145,11 +145,19 @@ class Executor:
         Calls tick until is_end_motion() returns True.
         :param timeout: Max number of ticks to perform.
         """
-        for i in range(timeout):
-            self.tick()
-            if self.motion_statechart.is_end_motion():
-                return
-        raise TimeoutError("Timeout reached while waiting for end of motion.")
+        try:
+            for i in range(timeout):
+                self.tick()
+                if self.motion_statechart.is_end_motion():
+                    return
+            raise TimeoutError("Timeout reached while waiting for end of motion.")
+        finally:
+            self._set_velocity_acceleration_jerk_to_zero()
+
+    def _set_velocity_acceleration_jerk_to_zero(self):
+        self.world.state.velocities[:] = 0
+        self.world.state.accelerations[:] = 0
+        self.world.state.jerks[:] = 0
 
     def _compile_qp_controller(self, controller_config: QPControllerConfig):
         ordered_dofs = sorted(

--- a/giskardpy/motion_statechart/exceptions.py
+++ b/giskardpy/motion_statechart/exceptions.py
@@ -54,7 +54,7 @@ def serialize_exception(obj: Exception) -> Dict[str, Any]:
     }
 
 
-def deserialize_exception(data: Dict[str, Any]) -> Exception:
+def deserialize_exception(data: Dict[str, Any], **kwargs) -> Exception:
 
     return Exception(data["value"])
 

--- a/test/test_motion_statechart/test_motion_statechart.py
+++ b/test/test_motion_statechart/test_motion_statechart.py
@@ -512,6 +512,9 @@ def test_two_goals(pr2_world: World):
 
     kin_sim.tick_until_end()
     assert np.isclose(torso_joint.position, 0.1, atol=1e-4)
+    assert np.allclose(pr2_world.state.velocities, 0)
+    assert np.allclose(pr2_world.state.accelerations, 0)
+    assert np.allclose(pr2_world.state.jerks, 0)
 
 
 def test_reset():

--- a/test/test_motion_statechart/test_motion_statechart.py
+++ b/test/test_motion_statechart/test_motion_statechart.py
@@ -477,6 +477,43 @@ def test_joint_goal():
     )
 
 
+def test_two_goals(pr2_world: World):
+    torso_joint = pr2_world.get_connection_by_name("torso_lift_joint")
+    r_wrist_roll_joint = pr2_world.get_connection_by_name("r_wrist_roll_joint")
+    msc = MotionStatechart()
+    msc.add_nodes(
+        [
+            JointPositionList(goal_state=JointState({torso_joint: 0.1})),
+            local_min := LocalMinimumReached(),
+        ]
+    )
+    msc.add_node(EndMotion.when_true(local_min))
+
+    kin_sim = Executor(
+        world=pr2_world,
+        controller_config=QPControllerConfig.create_default_with_50hz(),
+    )
+    kin_sim.compile(motion_statechart=msc)
+
+    kin_sim.tick_until_end()
+    assert np.isclose(torso_joint.position, 0.1, atol=1e-4)
+
+    msc = MotionStatechart()
+    msc.add_node(
+        joint_goal := JointPositionList(goal_state=JointState({r_wrist_roll_joint: 1}))
+    )
+    msc.add_node(EndMotion.when_true(joint_goal))
+
+    kin_sim = Executor(
+        world=pr2_world,
+        controller_config=QPControllerConfig.create_default_with_50hz(),
+    )
+    kin_sim.compile(motion_statechart=msc)
+
+    kin_sim.tick_until_end()
+    assert np.isclose(torso_joint.position, 0.1, atol=1e-4)
+
+
 def test_reset():
     msc = MotionStatechart()
     node1 = ConstTrueNode()


### PR DESCRIPTION
fixes a bug where giskard would continue with the velocity from the previous MSC, if the last one didn't set it to 0